### PR TITLE
Add push and set-remote commands and bump to v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ got diff                        # Display the differences in the file from the l
 ---
 
 ## Contributing
-Pull requests are welcome!
+Yes!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A minimalist version control system built in Go.
 ---
 
 ## Features
-- Initializes a local repository
-- Add files to staging area and commit it with a message
+- Initialize a local repository
+- Add files to the staging area and commit it with a message
 - View current status of tracked files
 - Restore previous commits using its hash
 - Pure Go CLI with **0** external dependencies
@@ -16,9 +16,9 @@ A minimalist version control system built in Go.
 
 ### Windows
 
-1. **Download the latest release from *[Github Releases](https://github.com/joaberch/got/releases)***
-2. **Extract the ZIP archive**
-3. **Run ``setup-windows.bat`` as an administrator**.
+1. **Download the latest release from *[GitHub Releases](https://github.com/joaberch/got/releases)***
+2. **Extract the ZIP archive.**
+3. **Run ``setup-windows.bat`` as an administrator.**
 
 This will :
 - Move the binary to a ``utils`` folder in the user directory.
@@ -29,9 +29,9 @@ This will :
 > - Add that folder to the system ``PATH``
 
 ### Linux / MacOS
-1. **Download the latest release from *[Github Releases](https://github.com/joaberch/got/releases)***.
-2. Extract the TAR archive.
-3. Run the setup script : `bash setup-linux.sh`.
+1. **Download the latest release from *[GitHub Releases](https://github.com/joaberch/got/releases)***.
+2. **Extract the TAR archive.**
+3. **Run the setup script : `bash setup-linux.sh`.**
 
 This will :
 - Move the binary to `~/utils`.
@@ -95,7 +95,7 @@ got diff                        # Display the differences in the file from the l
 - [x] Basic init/stage/commit
 - [x] Restore commit
 - [ ] Use the branch system
-- [ ] got diff
+- [x] got diff
 - [ ] Push on remote server
 - [ ] Restore using a more user-friendly way
 

--- a/README.md
+++ b/README.md
@@ -47,38 +47,39 @@ This will :
 
 ### Help and version
 
-```
+```bash
 got help                        # Show help
 got version                     # Show current version
 ```
 
 ### Initialize a repository
 
-```
+```bash
 got init                        # Create a .got repository
 ```
 
 ### Add and commit files
 
-```
+```bash
 got add main.go                 # Add the file to the staging area
 got commit "Initial commit"     # Creates a commit with a message
 ```
 
 ### Restore a file
 
-```
+```bash
 got restore abc123commithash    # Restore the file from commit hash
 ```
 
 ### Display log
 
-```
+```bash
 got log                         # Display the log
 ```
 
 ### Display differences from last commit
-```
+
+```bash
 got diff                        # Display the differences in the file from the latest commit
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A minimalist version control system built in Go.
 
 This will :
 - Move the binary to a ``utils`` folder in the user directory.
-- Add the ``utils`` folder to the system ``PATH`` variable so ``gosearch`` can be run everywhere.
+- Add the ``utils`` folder to the system ``PATH`` variable so ``got`` can be run everywhere.
 
 > Manual setup :
 > - Move the binary to a specific folder

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ got diff                        # Display the differences in the file from the l
 - [ ] Use the branch system
 - [x] got diff
 - [ ] Push on remote server
-- [ ] Restore using a more user-friendly way
 
 ---
 

--- a/check_tests.sh
+++ b/check_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+missing=()
+
+for file in $(find . -type f -name "*.go" ! -path "./unit_tests/*" ! -name "*_test.go"); do
+  base=$(basename "$file" .go)
+  dir=$(dirname "$file")
+  test_path="unit_tests/${dir}_test/${base}_test.go"
+  if [ ! -f "$test_path" ]; then
+    missing+=("$file")
+  fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "Go file without unit tests:"
+  for f in "${missing[@]}"; do
+    echo " - $f"
+  done
+  exit 1
+else
+  echo "All files have unit tests"
+fi

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -8,12 +8,6 @@ import (
 	"strings"
 )
 
-// Add stages the file at the given path by creating a blob from its contents
-// and recording the blob's hash in the repository staging area.
-//
-// The path is the filesystem path of the file to stage; the function reads the
-// file contents, constructs a model.Blob, generates its hash, and writes an
-// entry (path and hash) into the staging area. This function does not return
 // Add stages the file at the given path by creating a blob from its contents,
 // computing its hash, and recording the path→hash pair in the staging area.
 // 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -14,7 +14,12 @@ import (
 // The path is the filesystem path of the file to stage; the function reads the
 // file contents, constructs a model.Blob, generates its hash, and writes an
 // entry (path and hash) into the staging area. This function does not return
-// an error.
+// Add stages the file at the given path by creating a blob from its contents,
+// computing its hash, and recording the path→hash pair in the staging area.
+// 
+// The function returns an error if the path contains ".got" (the tool ignores
+// its own metadata files), if the file contents cannot be read, or if writing
+// the entry to the staging area fails.
 func Add(path string) error {
 	if strings.Contains(path, ".got") {
 		return errors.New("path contains '.got', got doesn't process itself")

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -12,11 +12,11 @@ import (
 
 // Add stages the file at the given path by creating a blob from its contents,
 // computing its hash, and recording the path→hash pair in the staging area.
-// 
+//
 // The function returns an error if the path contains ".got" (the tool ignores
 // its own metadata files), if the file contents cannot be read, or if writing
 // the entry to the staging area fails.
-func Add(path string) error {
+func Add(path string) error { //TODO - auto-stage from file already added
 	if strings.Contains(path, ".got") {
 		return errors.New("path contains '.got', got doesn't process itself")
 	}

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -23,13 +23,13 @@ func Add(path string) error { //TODO - auto-stage from file already added
 
 	f, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("os.Stat(%s): %v", path, err)
+		return fmt.Errorf("os.Stat(%s): %w", path, err)
 	}
 
 	if f.IsDir() { //If dir, recursive
 		entries, err := os.ReadDir(path)
 		if err != nil {
-			return fmt.Errorf("os.ReadDir(%s): %v", path, err)
+			return fmt.Errorf("os.ReadDir(%s): %w", path, err)
 		}
 
 		for _, entry := range entries {
@@ -47,7 +47,7 @@ func Add(path string) error { //TODO - auto-stage from file already added
 		//Read the file
 		contents, err := utils.GetFileContent(path)
 		if err != nil {
-			return fmt.Errorf("error getting file contents: %s", err)
+			return fmt.Errorf("error getting file contents: %w", err)
 		}
 
 		blob := model.Blob{
@@ -60,7 +60,7 @@ func Add(path string) error { //TODO - auto-stage from file already added
 		//Add (the relative path, hash, (perm)) to staging.csv
 		err = utils.AddToStaging(path, blob.Hash)
 		if err != nil {
-			return fmt.Errorf("error adding to staging file: %s", err)
+			return fmt.Errorf("error adding to staging file: %w", err)
 		}
 	}
 	return nil

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"github.com/joaberch/got/internal/model"
 	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -19,23 +21,47 @@ func Add(path string) error {
 		return errors.New("path contains '.got', got doesn't process itself")
 	}
 
-	//Read the file
-	contents, err := utils.GetFileContent(path)
+	f, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("error getting file contents: %s", err)
+		return fmt.Errorf("os.Stat(%s): %v", path, err)
 	}
 
-	blob := model.Blob{
-		Content: contents,
-	}
+	if f.IsDir() { //If dir, recursive
+		entries, err := os.ReadDir(path)
+		if err != nil {
+			return fmt.Errorf("os.ReadDir(%s): %v", path, err)
+		}
 
-	//Get file hash
-	blob.GenerateHash()
+		for _, entry := range entries {
+			entryPath := filepath.Join(path, entry.Name())
+			if strings.Contains(entryPath, ".got") {
+				continue
+			}
 
-	//Add (the relative path, hash, (perm)) to staging.csv
-	err = utils.AddToStaging(path, blob.Hash)
-	if err != nil {
-		return fmt.Errorf("error adding to staging file: %s", err)
+			err = Add(entryPath)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		//Read the file
+		contents, err := utils.GetFileContent(path)
+		if err != nil {
+			return fmt.Errorf("error getting file contents: %s", err)
+		}
+
+		blob := model.Blob{
+			Content: contents,
+		}
+
+		//Get file hash
+		blob.GenerateHash()
+
+		//Add (the relative path, hash, (perm)) to staging.csv
+		err = utils.AddToStaging(path, blob.Hash)
+		if err != nil {
+			return fmt.Errorf("error adding to staging file: %s", err)
+		}
 	}
 	return nil
 }

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -16,7 +16,7 @@ import (
 // The function returns an error if the path contains ".got" (the tool ignores
 // its own metadata files), if the file contents cannot be read, or if writing
 // the entry to the staging area fails.
-func Add(path string) error { //TODO - auto-stage from file already added
+func Add(path string) error {
 	if strings.Contains(path, ".got") {
 		return errors.New("path contains '.got', got doesn't process itself")
 	}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -8,13 +8,6 @@ import (
 	"time"
 )
 
-// Commit creates a new commit from the current staging state.
-//
-// It builds the tree and blob objects from .got/staging.csv, writes the tree and commit
-// objects into the object store, appends the new commit to .got/commits.csv, updates HEAD,
-// and clears the staging file.
-//
-// The message parameter is used as the commit message. On write/serialization failures the
 // Commit creates a new commit from the current staging state (.got/staging.csv) and updates the repository.
 //
 // It reads the staging file, generates a tree and its blobs, writes the tree and commit objects to the object store,

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -15,7 +15,13 @@ import (
 // and clears the staging file.
 //
 // The message parameter is used as the commit message. On write/serialization failures the
-// function calls log.Fatal and terminates the program.
+// Commit creates a new commit from the current staging state (.got/staging.csv) and updates the repository.
+//
+// It reads the staging file, generates a tree and its blobs, writes the tree and commit objects to the object store,
+// appends the commit to .got/commits.csv, updates .got/head with the new commit hash, and clears the staging file.
+//
+// The message parameter is used as the commit message.
+// Returns an error if any step (reading staging, hashing/serializing, writing objects, updating commits/head, or clearing staging) fails.
 func Commit(message string) error {
 	stagingPath := filepath.Join(".got", "staging.csv")
 	commitsPath := filepath.Join(".got", "commits.csv")

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -45,7 +45,7 @@ func Commit(message []string) error {
 	commit := model.Commit{
 		TreeHash:   treeHash,
 		ParentHash: latestCommitHash,
-		Author:     "TODO - none for MVP",
+		Author:     "anonymous",
 		Message:    strings.Join(message, " "),
 		Timestamp:  time.Now().Unix(),
 	}

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -21,24 +21,24 @@ func Commit(message string) error {
 
 	tree, err := utils.ReadStagingFile(stagingPath)
 	if err != nil {
-		return fmt.Errorf("error reading staging file: %s", err)
+		return fmt.Errorf("error reading staging file: %w", err)
 	}
 	if len(tree.Entries) == 0 {
 		return fmt.Errorf("cannot commit: staging area is empty")
 	}
 	treeHash, err := tree.GenerateHash()
 	if err != nil {
-		return fmt.Errorf("error generating tree hash: %s", err)
+		return fmt.Errorf("error generating tree hash: %w", err)
 	}
 
 	err = utils.CreateBlobs(tree) //.got/objects/blobs
 	if err != nil {
-		return fmt.Errorf("error creating blobs: %s", err)
+		return fmt.Errorf("error creating blobs: %w", err)
 	}
 
 	latestCommitHash, err := utils.GetLatestCommitHash()
 	if err != nil {
-		return fmt.Errorf("error getting latest commit hash: %s", err)
+		return fmt.Errorf("error getting latest commit hash: %w", err)
 	}
 
 	commit := model.Commit{
@@ -51,42 +51,42 @@ func Commit(message string) error {
 
 	treeSerialized, err := tree.Serialize()
 	if err != nil {
-		return fmt.Errorf("error serializing tree: %s", err)
+		return fmt.Errorf("error serializing tree: %w", err)
 	}
 	err = utils.WriteObject("trees", treeHash, treeSerialized) //.got/objects/trees
 	if err != nil {
-		return fmt.Errorf("error writing trees: %s", err)
+		return fmt.Errorf("error writing trees: %w", err)
 	}
 
 	commitSerialized, err := commit.Serialize()
 	if err != nil {
-		return fmt.Errorf("error serializing commit: %s", err)
+		return fmt.Errorf("error serializing commit: %w", err)
 	}
 	commitHash := commit.Hash(commitSerialized)
 
 	err = utils.WriteObject("commits", commitHash, commitSerialized)
 	if err != nil {
-		return fmt.Errorf("error writing commits: %s", err)
+		return fmt.Errorf("error writing commits: %w", err)
 	}
 
 	err = utils.AddToCommits(commitsPath, commitHash, commit)
 	if err != nil {
-		return fmt.Errorf("error adding to commits: %s", err)
+		return fmt.Errorf("error adding to commits: %w", err)
 	}
 	headPath := filepath.Join(".got", "head")
 	err = utils.AddToHead(headPath, commitHash)
 	if err != nil {
-		return fmt.Errorf("error adding to head: %s", err)
+		return fmt.Errorf("error adding to head: %w", err)
 	}
 
 	err = utils.ClearFile(stagingPath)
 	if err != nil {
-		return fmt.Errorf("error clearing staging file: %s", err)
+		return fmt.Errorf("error clearing staging file: %w", err)
 	}
 
 	err = utils.UpdateIndexedPaths(tree)
 	if err != nil {
-		return fmt.Errorf("error updating indexed paths: %s", err)
+		return fmt.Errorf("error updating indexed paths: %w", err)
 	}
 
 	return nil

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -80,5 +80,11 @@ func Commit(message string) error {
 	if err != nil {
 		return fmt.Errorf("error clearing staging file: %s", err)
 	}
+
+	err = utils.UpdateIndexedPaths(tree)
+	if err != nil {
+		return fmt.Errorf("error updating indexed paths: %s", err)
+	}
+
 	return nil
 }

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -23,6 +23,9 @@ func Commit(message string) error {
 	if err != nil {
 		return fmt.Errorf("error reading staging file: %s", err)
 	}
+	if len(tree.Entries) == 0 {
+		return fmt.Errorf("cannot commit: staging area is empty")
+	}
 	treeHash, err := tree.GenerateHash()
 	if err != nil {
 		return fmt.Errorf("error generating tree hash: %s", err)

--- a/cmd/commit.go
+++ b/cmd/commit.go
@@ -5,6 +5,7 @@ import (
 	"github.com/joaberch/got/internal/model"
 	"github.com/joaberch/got/utils"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -15,7 +16,7 @@ import (
 //
 // The message parameter is used as the commit message.
 // Returns an error if any step (reading staging, hashing/serializing, writing objects, updating commits/head, or clearing staging) fails.
-func Commit(message string) error {
+func Commit(message []string) error {
 	stagingPath := filepath.Join(".got", "staging.csv")
 	commitsPath := filepath.Join(".got", "commits.csv")
 
@@ -45,7 +46,7 @@ func Commit(message string) error {
 		TreeHash:   treeHash,
 		ParentHash: latestCommitHash,
 		Author:     "TODO - none for MVP",
-		Message:    message,
+		Message:    strings.Join(message, " "),
 		Timestamp:  time.Now().Unix(),
 	}
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -7,6 +7,13 @@ import (
 	"os"
 )
 
+// Diff compares the current working-tree files against the latest commit and prints per-file line-based
+// differences for any files that have changed.
+//
+// It resolves the latest commit, walks the commit tree, and for each tree entry compares the committed blob
+// content to the current file on disk. Per-entry read errors are printed and that entry is skipped.
+//
+// Returns an error only if resolving the latest commit hash or the commit object fails; otherwise it returns nil.
 func Diff() error {
 	//head -> contains latest commit hash
 	headHash, err := utils.GetLatestCommitHash()

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -14,7 +14,7 @@ import (
 // content to the current file on disk. Per-entry read errors are printed and that entry is skipped.
 //
 // Returns an error only if resolving the latest commit hash or the commit object fails; otherwise it returns nil.
-func Diff() error { //TODO - parameter to display error
+func Diff(verbose bool) error { //TODO - parameter to display error
 	//head -> contains latest commit hash
 	headHash, err := utils.GetLatestCommitHash()
 	if err != nil {
@@ -58,13 +58,17 @@ func Diff() error { //TODO - parameter to display error
 			}
 			continue
 		} else if err != nil {
-			fmt.Printf("Failed to get committed blob: %v", err)
+			if verbose {
+				fmt.Printf("Failed to get committed blob: %v", err)
+			}
 			continue
 		}
 
 		committedBlob, err := utils.GetBlobFromHash(lastBlobHash)
 		if err != nil {
-			fmt.Printf("Failed to get committed blob: %v", err)
+			if verbose {
+				fmt.Printf("Failed to get committed blob: %v", err)
+			}
 			continue
 		}
 
@@ -80,7 +84,9 @@ func Diff() error { //TODO - parameter to display error
 			fmt.Printf("New file staged: %s\n", stagedPath)
 			currentData, err := utils.GetFileContent(stagedPath)
 			if err != nil {
-				fmt.Printf("failed to read file: %v", err)
+				if verbose {
+					fmt.Printf("failed to read file: %v", err)
+				}
 				continue
 			}
 			utils.ShowLineDiff("", string(currentData))

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -14,7 +14,7 @@ import (
 // content to the current file on disk. Per-entry read errors are printed and that entry is skipped.
 //
 // Returns an error only if resolving the latest commit hash or the commit object fails; otherwise it returns nil.
-func Diff() error {
+func Diff() error { //TODO - parameter to display error
 	//head -> contains latest commit hash
 	headHash, err := utils.GetLatestCommitHash()
 	if err != nil {
@@ -38,28 +38,39 @@ func Diff() error {
 		return err
 	}
 
+	indexedMap, err := utils.GetIndexedPathsWithHash()
+	if err != nil {
+		return fmt.Errorf("failed to get indexed paths: %v", err)
+	}
+
 	commitedFiles := make(map[string]string)
 	for _, entry := range tree.Entries {
 		commitedFiles[entry.Name] = entry.Hash
 	}
 
-	//Detect the modified file
-	for name, hash := range commitedFiles {
-		commitedBlob, err := utils.GetBlobFromHash(hash)
-		if err != nil {
-			fmt.Printf("failed to get commited blob: %v", err)
+	for path, lastBlobHash := range indexedMap {
+		currentData, err := os.ReadFile(path)
+		if os.IsNotExist(err) {
+			fmt.Printf("Deleted file: %s\n", path)
+			committedBlob, err := utils.GetBlobFromHash(lastBlobHash)
+			if err == nil {
+				utils.ShowLineDiff(string(committedBlob.Content), "")
+			}
+			continue
+		} else if err != nil {
+			fmt.Printf("Failed to get committed blob: %v", err)
 			continue
 		}
 
-		currentData, err := os.ReadFile(name)
+		committedBlob, err := utils.GetBlobFromHash(lastBlobHash)
 		if err != nil {
-			fmt.Printf("failed to read file: %v", err)
+			fmt.Printf("Failed to get committed blob: %v", err)
 			continue
 		}
 
-		if !bytes.Equal(currentData, commitedBlob.Content) {
-			fmt.Printf("Modified file: %s\n", name)
-			utils.ShowLineDiff(string(commitedBlob.Content), string(currentData))
+		if !bytes.Equal(committedBlob.Content, currentData) {
+			fmt.Printf("Modified file: %s\n", path)
+			utils.ShowLineDiff(string(committedBlob.Content), string(currentData))
 		}
 	}
 
@@ -70,24 +81,11 @@ func Diff() error {
 			currentData, err := os.ReadFile(stagedPath)
 			if err != nil {
 				fmt.Printf("failed to read file: %v", err)
+				continue
 			}
 			utils.ShowLineDiff("", string(currentData))
 		}
 	}
 
-	//Detect the deleted file
-	for name, hash := range commitedFiles {
-		_, err = os.Stat(name)
-		if os.IsNotExist(err) {
-			fmt.Printf("Deleted file: %s\n", name)
-
-			commitedBlob, err := utils.GetBlobFromHash(hash)
-			if err != nil {
-				fmt.Printf("failed to get commited blob: %v", err)
-				continue
-			}
-			utils.ShowLineDiff(string(commitedBlob.Content), "")
-		}
-	}
 	return nil
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -49,7 +49,7 @@ func Diff() error { //TODO - parameter to display error
 	}
 
 	for path, lastBlobHash := range indexedMap {
-		currentData, err := os.ReadFile(path)
+		currentData, err := utils.GetFileContent(path)
 		if os.IsNotExist(err) {
 			fmt.Printf("Deleted file: %s\n", path)
 			committedBlob, err := utils.GetBlobFromHash(lastBlobHash)
@@ -78,7 +78,7 @@ func Diff() error { //TODO - parameter to display error
 	for _, stagedPath := range stagedEntries {
 		if _, exists := committedFiles[stagedPath]; !exists {
 			fmt.Printf("New file staged: %s\n", stagedPath)
-			currentData, err := os.ReadFile(stagedPath)
+			currentData, err := utils.GetFileContent(stagedPath)
 			if err != nil {
 				fmt.Printf("failed to read file: %v", err)
 				continue

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -43,9 +43,9 @@ func Diff() error { //TODO - parameter to display error
 		return fmt.Errorf("failed to get indexed paths: %v", err)
 	}
 
-	commitedFiles := make(map[string]string)
+	committedFiles := make(map[string]string)
 	for _, entry := range tree.Entries {
-		commitedFiles[entry.Name] = entry.Hash
+		committedFiles[entry.Name] = entry.Hash
 	}
 
 	for path, lastBlobHash := range indexedMap {
@@ -76,7 +76,7 @@ func Diff() error { //TODO - parameter to display error
 
 	//Detect the added file
 	for _, stagedPath := range stagedEntries {
-		if _, exists := commitedFiles[stagedPath]; !exists {
+		if _, exists := committedFiles[stagedPath]; !exists {
 			fmt.Printf("New file staged: %s\n", stagedPath)
 			currentData, err := os.ReadFile(stagedPath)
 			if err != nil {

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -29,27 +29,64 @@ func Diff() error {
 
 	//Tree -> contains hash of blob(s)
 	tree, err := utils.GetTreeFromCommit(commit)
+	if err != nil {
+		return fmt.Errorf("failed to get tree: %v", err)
+	}
 
-	//Compare each file in the tree with its current version
+	stagedEntries, err := utils.GetStagedEntries()
+	if err != nil {
+		return err
+	}
+
+	commitedFiles := make(map[string]string)
 	for _, entry := range tree.Entries {
-		committedBlob, err := utils.GetBlobFromHash(entry.Hash)
-		committedData := committedBlob.Content
+		commitedFiles[entry.Name] = entry.Hash
+	}
+
+	//Detect the modified file
+	for name, hash := range commitedFiles {
+		commitedBlob, err := utils.GetBlobFromHash(hash)
 		if err != nil {
-			fmt.Printf("error reading blob file %s: %s", entry.Name, err)
+			fmt.Printf("failed to get commited blob: %v", err)
 			continue
 		}
 
-		currentData, err := os.ReadFile(entry.Name)
+		currentData, err := os.ReadFile(name)
 		if err != nil {
-			fmt.Printf("error reading blob file %s: %s", entry.Name, err)
+			fmt.Printf("failed to read file: %v", err)
 			continue
 		}
 
-		if !bytes.Equal(currentData, committedData) {
-			fmt.Printf("Diff for %s:\n", entry.Name)
-			utils.ShowLineDiff(string(committedData), string(currentData))
-		} else {
-			fmt.Printf("No changes from the last commit")
+		if !bytes.Equal(currentData, commitedBlob.Content) {
+			fmt.Printf("Modified file: %s\n", name)
+			utils.ShowLineDiff(string(commitedBlob.Content), string(currentData))
+		}
+	}
+
+	//Detect the added file
+	for _, stagedPath := range stagedEntries {
+		if _, exists := commitedFiles[stagedPath]; !exists {
+			fmt.Printf("New file staged: %s\n", stagedPath)
+			currentData, err := os.ReadFile(stagedPath)
+			if err != nil {
+				fmt.Printf("failed to read file: %v", err)
+			}
+			utils.ShowLineDiff("", string(currentData))
+		}
+	}
+
+	//Detect the deleted file
+	for name, hash := range commitedFiles {
+		_, err = os.Stat(name)
+		if os.IsNotExist(err) {
+			fmt.Printf("Deleted file: %s\n", name)
+
+			commitedBlob, err := utils.GetBlobFromHash(hash)
+			if err != nil {
+				fmt.Printf("failed to get commited blob: %v", err)
+				continue
+			}
+			utils.ShowLineDiff(string(commitedBlob.Content), "")
 		}
 	}
 	return nil

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -18,19 +18,19 @@ func Diff(verbose bool) error {
 	//head -> contains latest commit hash
 	headHash, err := utils.GetLatestCommitHash()
 	if err != nil {
-		return fmt.Errorf("failed to get latest commit hash: %v", err)
+		return fmt.Errorf("failed to get latest commit hash: %w", err)
 	}
 
 	//Commit -> contains tree hash
 	commit, err := utils.GetCommitFromHash(headHash)
 	if err != nil {
-		return fmt.Errorf("failed to get commit: %v", err)
+		return fmt.Errorf("failed to get commit: %w", err)
 	}
 
 	//Tree -> contains hash of blob(s)
 	tree, err := utils.GetTreeFromCommit(commit)
 	if err != nil {
-		return fmt.Errorf("failed to get tree: %v", err)
+		return fmt.Errorf("failed to get tree: %w", err)
 	}
 
 	stagedEntries, err := utils.GetStagedEntries()
@@ -40,7 +40,7 @@ func Diff(verbose bool) error {
 
 	indexedMap, err := utils.GetIndexedPathsWithHash()
 	if err != nil {
-		return fmt.Errorf("failed to get indexed paths: %v", err)
+		return fmt.Errorf("failed to get indexed paths: %w", err)
 	}
 
 	committedFiles := make(map[string]string)

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -13,8 +13,8 @@ import (
 // It resolves the latest commit, walks the commit tree, and for each tree entry compares the committed blob
 // content to the current file on disk. Per-entry read errors are printed and that entry is skipped.
 //
-// Returns an error only if resolving the latest commit hash or the commit object fails; otherwise it returns nil.
-func Diff(verbose bool) error { //TODO - parameter to display error
+// Returns an error only if resolving the latest commit hash, or the commit object fails; otherwise it returns nil.
+func Diff(verbose bool) error {
 	//head -> contains latest commit hash
 	headHash, err := utils.GetLatestCommitHash()
 	if err != nil {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -3,7 +3,9 @@ package cmd
 import "fmt"
 
 // ShowHelp prints the command-line help and usage information for Got to standard output.
-// The message includes available commands, short forms, usage examples, and the project source URL.
+// ShowHelp prints the command-line help and usage information for Got to standard output.
+// The output includes the tool title, usage line, available commands with short forms,
+// example commands, and the project source URL.
 func ShowHelp() {
 	fmt.Println("Got - A simple version control system\n" +
 		"\n" +

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -3,7 +3,6 @@ package cmd
 import "fmt"
 
 // ShowHelp prints the command-line help and usage information for Got to standard output.
-// ShowHelp prints the command-line help and usage information for Got to standard output.
 // The output includes the tool title, usage line, available commands with short forms,
 // example commands, and the project source URL.
 func ShowHelp() {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ func ShowHelp() {
 		"  commit <msg>			Commit staged changes with a message\n" +
 		"  restore <id>			Restore a file from a previous commit by hash\n" +
 		"  log					Display the log from the commits file\n" +
-		"  diff					Display the differences in the file from the last commit who changed that file\n" +
+		"  diff	[-v]			Display the differences in the file from the last commit who changed that file, verbose option\n" +
 		"\n" +
 		"Examples:\n" +
 		"  got init\n" +

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -12,15 +12,15 @@ func ShowHelp() {
 		"  got <command> [arguments]\n" +
 		"\n" +
 		"Available Commands:\n" +
-		"  help, h         Show this help message\n" +
-		"  version, v      Display the current version of Got\n" +
-		"  init, i         Initialize a new Got repository\n" +
-		"  add, a <file>   Add a file to the staging area\n" +
-		"  status, s       Show the status of the working directory\n" +
-		"  commit, c <msg> Commit staged changes with a message\n" +
-		"  restore, r <id> Restore a file from a previous commit by hash\n" +
-		"  log, l          Display the log from the commits file\n" +
-		"  diff, d         Display the differences in the file from the last commit" + //TODO - get (distinct) all files from all commits and use all of them for a better diff display
+		"  help					Show this help message\n" +
+		"  version				Display the current version of Got\n" +
+		"  init					Initialize a new Got repository\n" +
+		"  add <file>			Add a file to the staging area\n" +
+		"  status				Show the status of the working directory\n" +
+		"  commit <msg>			Commit staged changes with a message\n" +
+		"  restore <id>			Restore a file from a previous commit by hash\n" +
+		"  log					Display the log from the commits file\n" +
+		"  diff					Display the differences in the file from the last commit" + //TODO - get (distinct) all files from all commits and use all of them for a better diff display
 		"\n" +
 		"Examples:\n" +
 		"  got init\n" +

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ func ShowHelp() {
 		"  commit <msg>			Commit staged changes with a message\n" +
 		"  restore <id>			Restore a file from a previous commit by hash\n" +
 		"  log					Display the log from the commits file\n" +
-		"  diff					Display the differences in the file from the last commit" +
+		"  diff					Display the differences in the file from the last commit who changed that file\n" +
 		"\n" +
 		"Examples:\n" +
 		"  got init\n" +

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -20,7 +20,7 @@ func ShowHelp() {
 		"  commit <msg>			Commit staged changes with a message\n" +
 		"  restore <id>			Restore a file from a previous commit by hash\n" +
 		"  log					Display the log from the commits file\n" +
-		"  diff					Display the differences in the file from the last commit" + //TODO - get (distinct) all files from all commits and use all of them for a better diff display
+		"  diff					Display the differences in the file from the last commit" +
 		"\n" +
 		"Examples:\n" +
 		"  got init\n" +

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,7 +13,11 @@ import (
 // If the current working directory cannot be determined or a .got directory
 // already exists, the function logs a fatal error and exits the process.
 // Otherwise, it creates the mandatory files and folders defined in
-// model.FilesList under the newly created .got directory using utils.CreateFilePath.
+// Init creates a ".got" directory in the current working directory and populates it
+// with the mandatory files and folders defined in model.FilesList using
+// utils.CreateFilePath. It returns an error if the working directory cannot be
+// determined, if the ".got" directory already exists, or if creating any required
+// file or directory fails.
 func Init() error {
 	pwd, err := os.Getwd() //get current folder
 	if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -8,11 +8,6 @@ import (
 	"path/filepath"
 )
 
-// Init initializes a .got directory in the current working directory.
-//
-// If the current working directory cannot be determined or a .got directory
-// already exists, the function logs a fatal error and exits the process.
-// Otherwise, it creates the mandatory files and folders defined in
 // Init creates a ".got" directory in the current working directory and populates it
 // with the mandatory files and folders defined in model.FilesList using
 // utils.CreateFilePath. It returns an error if the working directory cannot be

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -16,19 +16,19 @@ import (
 func Init() error {
 	pwd, err := os.Getwd() //get current folder
 	if err != nil {
-		return fmt.Errorf("error getting working directory: %s", err)
+		return fmt.Errorf("error getting working directory: %w", err)
 	}
 	gotPath := filepath.Join(pwd, ".got")
 
 	if _, err = os.Stat(gotPath); !os.IsNotExist(err) { //Check if already exist
-		return fmt.Errorf("this directory already exists: %s: %s", gotPath, err)
+		return fmt.Errorf("this directory already exists: %s: %w", gotPath, err)
 	}
 
 	for name, fileType := range model.FilesList { //Create mandatory files/folder
 		fullPath := filepath.Join(gotPath, name)
 		err = utils.CreateFilePath(fullPath, fileType)
 		if err != nil {
-			return fmt.Errorf("error creating file %s: %s", name, err)
+			return fmt.Errorf("error creating file %s: %w", name, err)
 		}
 	}
 	return nil

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 )
 
+// Log reads commits from the repository metadata file (.got/commits.csv) and displays each valid commit.
+// It skips CSV rows with fewer than five fields. The function returns an error if the commits file cannot
+// be read, if the CSV cannot be parsed, or if a commit timestamp cannot be converted to an int64. On
+// success it returns nil.
 func Log() error {
 	commitsPath := filepath.Join(".got", "commits.csv")
 	contents, err := utils.GetFileContent(commitsPath)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -18,13 +18,13 @@ func Log() error {
 	commitsPath := filepath.Join(".got", "commits.csv")
 	contents, err := utils.GetFileContent(commitsPath)
 	if err != nil {
-		return fmt.Errorf("error getting file contents: %s", err)
+		return fmt.Errorf("error getting file contents: %w", err)
 	}
 
 	csvReader := csv.NewReader(strings.NewReader(string(contents)))
 	records, err := csvReader.ReadAll()
 	if err != nil {
-		return fmt.Errorf("error reading file contents: %s", err)
+		return fmt.Errorf("error reading file contents: %w", err)
 	}
 
 	for _, record := range records {
@@ -34,7 +34,7 @@ func Log() error {
 
 		time, err := strconv.ParseInt(record[4], 10, 64)
 		if err != nil {
-			return fmt.Errorf("error converting time from file contents: %s", err)
+			return fmt.Errorf("error converting time from file contents: %w", err)
 		}
 		commitDisplay := model.CommitDisplay{
 			Hash:      record[0],

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -27,8 +27,7 @@ func Log() error {
 		return fmt.Errorf("error reading file contents: %s", err)
 	}
 
-	for i := 0; i <= len(records)-1; i++ {
-		record := records[i]
+	for _, record := range records {
 		if len(record) < 5 {
 			continue //Skip
 		}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -20,9 +20,12 @@ func Push() error {
 		return fmt.Errorf("error unmarshaling .gotconfig: %w", err)
 	}
 
-	remotePath, ok := config["local"]
-	if !ok {
-		return fmt.Errorf("no 'local' key in .gotconfig")
+	if remote, ok := config["remote"].(map[string]any); ok {
+		ip := remote["ip"].(string)
+		user := remote["user"].(string)
+		path := remote["path"].(string)
+		identityPath := filepath.Join(os.Getenv("USERPROFILE"), ".ssh", "id_rsa")
+		return utils.PushRemote(ip, user, path, identityPath)
 	}
 
 	if localPath, ok := config["local"].(string); ok {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -15,8 +15,8 @@ func Push() error {
 		return fmt.Errorf("error reading .gotconfig: %w", err)
 	}
 
-	var config map[string]string
-	if err := json.Unmarshal(data, &config); err != nil {
+	var config map[string]any
+	if err = json.Unmarshal(data, &config); err != nil {
 		return fmt.Errorf("error unmarshaling .gotconfig: %w", err)
 	}
 
@@ -25,26 +25,9 @@ func Push() error {
 		return fmt.Errorf("no 'local' key in .gotconfig")
 	}
 
-	if _, err = os.Stat(remotePath); os.IsNotExist(err) {
-		return fmt.Errorf("remote path does not exist: %s", remotePath)
+	if localPath, ok := config["local"].(string); ok {
+		return utils.PushLocal(localPath)
 	}
 
-	err = utils.CopyDir(".got/objects", filepath.Join(remotePath, "objects"))
-	if err != nil {
-		return fmt.Errorf("error copying remote objects: %w", err)
-	}
-
-	files := []string{"commits.csv", "head"}
-	for _, file := range files {
-		src := filepath.Join(".got", file)
-		dst := filepath.Join(remotePath, file)
-
-		err = utils.CopyFile(src, dst)
-		if err != nil {
-			return fmt.Errorf("error copying remote objects: %w", err)
-		}
-	}
-
-	fmt.Println("Pushed remote objects to:", remotePath)
-	return nil
+	return fmt.Errorf("no remote or local config found")
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+)
+
+// Push the objects to the local path
+func Push() error {
+	data, err := os.ReadFile(".got/.gotconfig")
+	if err != nil {
+		return fmt.Errorf("error reading .gotconfig: %w", err)
+	}
+
+	var config map[string]string
+	if err := json.Unmarshal(data, &config); err != nil {
+		return fmt.Errorf("error unmarshaling .gotconfig: %w", err)
+	}
+
+	remotePath, ok := config["local"]
+	if !ok {
+		return fmt.Errorf("no 'local' key in .gotconfig")
+	}
+
+	if _, err = os.Stat(remotePath); os.IsNotExist(err) {
+		return fmt.Errorf("remote path does not exist: %s", remotePath)
+	}
+
+	err = utils.CopyDir(".got/objects", filepath.Join(remotePath, "objects"))
+	if err != nil {
+		return fmt.Errorf("error copying remote objects: %w", err)
+	}
+
+	files := []string{"commits.csv", "head"}
+	for _, file := range files {
+		src := filepath.Join(".got", file)
+		dst := filepath.Join(remotePath, file)
+
+		err = utils.CopyFile(src, dst)
+		if err != nil {
+			return fmt.Errorf("error copying remote objects: %w", err)
+		}
+	}
+
+	fmt.Println("Pushed remote objects to:", remotePath)
+	return nil
+}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -14,7 +14,18 @@ import (
 // current working directory using the entry's Name (file mode 0644).
 //
 // commitHash is the hash of the commit object to restore.
-// The function exits the program via log.Fatal on any read/deserialize/write error.
+// Restore restores working-tree files from the commit identified by commitHash.
+// 
+// It reads the commit object at ".got/objects/commits/<commitHash>", deserializes it
+// to obtain the root tree hash, reads and deserializes the tree object at
+// ".got/objects/trees/<treeHash>", then writes each blob found in
+// ".got/objects/blobs/<blobHash>" to the working directory using the entry's Name
+// with file mode 0644.
+//
+// commitHash is the hash of the commit object to restore.
+//
+// Returns an error if any read, deserialization, or write operation fails. On
+// success the function prints "Files restored" and returns nil.
 func Restore(commitHash string) error {
 	objectPath := filepath.Join(".got", "objects", "commits", commitHash)
 

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -8,13 +8,6 @@ import (
 )
 
 // Restore restores working-tree files from the commit identified by commitHash.
-//
-// Restore reads the commit object at ".got/objects/commits/<commitHash>", loads the
-// commit's tree object, then writes each blob referenced by the tree into the
-// current working directory using the entry's Name (file mode 0644).
-//
-// commitHash is the hash of the commit object to restore.
-// Restore restores working-tree files from the commit identified by commitHash.
 // 
 // It reads the commit object at ".got/objects/commits/<commitHash>", deserializes it
 // to obtain the root tree hash, reads and deserializes the tree object at

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Restore restores working-tree files from the commit identified by commitHash.
-// 
+//
 // It reads the commit object at ".got/objects/commits/<commitHash>", deserializes it
 // to obtain the root tree hash, reads and deserializes the tree object at
 // ".got/objects/trees/<treeHash>", then writes each blob found in
@@ -17,12 +17,12 @@ import (
 //
 // commitHash is the hash of the commit object to restore.
 //
-// Returns an error if any read, deserialization, or write operation fails. On
-// success the function prints "Files restored" and returns nil.
+// Returns an error if any read, deserialization, or write operation fails.
+// On success, the function prints "Files restored" and returns nil.
 func Restore(commitHash string) error {
 	objectPath := filepath.Join(".got", "objects", "commits", commitHash)
 
-	data, err := os.ReadFile(objectPath)
+	data, err := utils.GetFileContent(objectPath)
 	if err != nil {
 		return fmt.Errorf("error reading file %s: %s", objectPath, err)
 	}
@@ -32,7 +32,7 @@ func Restore(commitHash string) error {
 	}
 
 	treePath := filepath.Join(".got", "objects", "trees", commit.TreeHash)
-	treeData, err := os.ReadFile(treePath)
+	treeData, err := utils.GetFileContent(treePath)
 	if err != nil {
 		return fmt.Errorf("error reading tree file %s: %s", treePath, err)
 	}
@@ -44,7 +44,7 @@ func Restore(commitHash string) error {
 
 	for _, entry := range tree.Entries {
 		blobPath := filepath.Join(".got", "objects", "blobs", entry.Hash)
-		blobData, err := os.ReadFile(blobPath)
+		blobData, err := utils.GetFileContent(blobPath)
 		if err != nil {
 			return fmt.Errorf("error reading blob file %s: %s", blobPath, err)
 		}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -24,34 +24,34 @@ func Restore(commitHash string) error {
 
 	data, err := utils.GetFileContent(objectPath)
 	if err != nil {
-		return fmt.Errorf("error reading file %s: %s", objectPath, err)
+		return fmt.Errorf("error reading file %s: %w", objectPath, err)
 	}
 	commit, err := utils.DeserializeCommit(data)
 	if err != nil {
-		return fmt.Errorf("error deserializing commit: %s", err)
+		return fmt.Errorf("error deserializing commit: %w", err)
 	}
 
 	treePath := filepath.Join(".got", "objects", "trees", commit.TreeHash)
 	treeData, err := utils.GetFileContent(treePath)
 	if err != nil {
-		return fmt.Errorf("error reading tree file %s: %s", treePath, err)
+		return fmt.Errorf("error reading tree file %s: %w", treePath, err)
 	}
 
 	tree, err := utils.DeserializeTree(treeData)
 	if err != nil {
-		return fmt.Errorf("error deserializing tree %s: %s", treePath, err)
+		return fmt.Errorf("error deserializing tree %s: %w", treePath, err)
 	}
 
 	for _, entry := range tree.Entries {
 		blobPath := filepath.Join(".got", "objects", "blobs", entry.Hash)
 		blobData, err := utils.GetFileContent(blobPath)
 		if err != nil {
-			return fmt.Errorf("error reading blob file %s: %s", blobPath, err)
+			return fmt.Errorf("error reading blob file %s: %w", blobPath, err)
 		}
 
 		err = os.WriteFile(entry.Name, blobData, 0644)
 		if err != nil {
-			return fmt.Errorf("error writing blob file %s: %s", blobPath, err)
+			return fmt.Errorf("error writing blob file %s: %w", blobPath, err)
 		}
 	}
 	fmt.Println("Files restored")

--- a/cmd/set-remote.go
+++ b/cmd/set-remote.go
@@ -18,7 +18,12 @@ func SetRemote(remoteType model.RemoteType, args []string) error {
 			return fmt.Errorf("invalid number of arguments")
 		}
 	case model.Remote:
-		//TODO
+		if len(args) == 5 { //set-remote remote ip user path
+			ip := args[2]
+			user := args[3]
+			path := args[4]
+			err = utils.ConfigRemotePush(ip, user, path)
+		}
 	case model.Git:
 		//TODO
 	}

--- a/cmd/set-remote.go
+++ b/cmd/set-remote.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/joaberch/got/internal/model"
+	"github.com/joaberch/got/utils"
+)
+
+// SetRemote configurates the push on a local server
+// got set-remote local /path
+func SetRemote(remoteType model.RemoteType, args []string) error {
+	var err error
+	switch remoteType {
+	case model.Local:
+		if len(args) == 3 { //set-remote type path
+			err = utils.ConfigLocalRemote(args[2])
+		} else {
+			return fmt.Errorf("invalid number of arguments")
+		}
+	case model.Remote:
+		//TODO
+	case model.Git:
+		//TODO
+	}
+	return err
+}

--- a/cmd/set-remote.go
+++ b/cmd/set-remote.go
@@ -13,7 +13,7 @@ func SetRemote(remoteType model.RemoteType, args []string) error {
 	switch remoteType {
 	case model.Local:
 		if len(args) == 3 { //set-remote type path
-			err = utils.ConfigLocalRemote(args[2])
+			err = utils.ConfigLocalPush(args[2])
 		} else {
 			return fmt.Errorf("invalid number of arguments")
 		}

--- a/internal/model/command_type.go
+++ b/internal/model/command_type.go
@@ -14,4 +14,5 @@ const (
 	CmdLog
 	CmdDiff
 	CmdSetRemote
+	CmdPush
 )

--- a/internal/model/command_type.go
+++ b/internal/model/command_type.go
@@ -13,4 +13,5 @@ const (
 	CmdRestore
 	CmdLog
 	CmdDiff
+	CmdSetRemote
 )

--- a/internal/model/commit_display.go
+++ b/internal/model/commit_display.go
@@ -16,6 +16,6 @@ func (commit CommitDisplay) Display() {
 	fmt.Printf("Commit : %s\n", commit.Hash)
 	fmt.Printf("Author : %s\n", commit.Author)
 	fmt.Printf("Message : %s\n", commit.Message)
-	readableTime := time.Unix(commit.Timestamp, 0).Format("2006-01-02 15:04:05")
+	readableTime := time.Unix(commit.Timestamp, 0).Format(time.DateTime)
 	fmt.Printf("Date     : %s\n\n", readableTime)
 }

--- a/internal/model/files_list.go
+++ b/internal/model/files_list.go
@@ -9,4 +9,5 @@ var FilesList = map[string]string{
 	"objects/blobs":     "Folder", //Contain serialized blobs with hash as name
 	"head":              "File",   //Store the latest commit hash (HEAD)
 	"indexed_paths.csv": "File",   //Store all the file path used to check the diff
+	".gotconfig":        "File",   //Contains the remote config
 }

--- a/internal/model/files_list.go
+++ b/internal/model/files_list.go
@@ -2,10 +2,11 @@ package model
 
 // FilesList lists all the mandatory file/folder
 var FilesList = map[string]string{
-	"staging.csv":     "File",   //Staging area
-	"commits.csv":     "File",   //Tracking file state
-	"objects/commits": "Folder", //Contain serialized commits with hash as name
-	"objects/trees":   "Folder", //Contain serialized trees with hash as name
-	"objects/blobs":   "Folder", //Contain serialized blobs with hash as name
-	"head":            "File",   //Store the latest commit hash (HEAD)
+	"staging.csv":       "File",   //Staging area
+	"commits.csv":       "File",   //Tracking file state
+	"objects/commits":   "Folder", //Contain serialized commits with hash as name
+	"objects/trees":     "Folder", //Contain serialized trees with hash as name
+	"objects/blobs":     "Folder", //Contain serialized blobs with hash as name
+	"head":              "File",   //Store the latest commit hash (HEAD)
+	"indexed_paths.csv": "File",   //Store all the file path used to check the diff
 }

--- a/internal/model/parsed_args.go
+++ b/internal/model/parsed_args.go
@@ -3,5 +3,6 @@ package model
 // ParsedArgs manages the argument parsing
 type ParsedArgs struct {
 	Command CommandType
+	Verbose bool
 	Other   string
 }

--- a/internal/model/remote-type.go
+++ b/internal/model/remote-type.go
@@ -1,0 +1,9 @@
+package model
+
+type RemoteType int
+
+const (
+	Local RemoteType = iota
+	Remote
+	Git
+)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,10 @@ import (
 	"os"
 )
 
-// missing commit message or missing restore hash terminate the program via log.Fatal.
+// main is the CLI entry point. It parses command-line arguments, dispatches the requested
+// subcommand (help, version, init, add, commit, restore, log, diff) to the cmd package,
+// and exits with a non-zero status if a command returns an error. Missing required
+// arguments for commit and restore cause an immediate fatal exit with an explanatory message.
 func main() {
 	var err error
 	args := os.Args[1:]

--- a/main.go
+++ b/main.go
@@ -53,6 +53,8 @@ func main() {
 		err = cmd.Log()
 	case model.CmdDiff:
 		err = cmd.Diff(parsed.Verbose)
+	case model.CmdSetRemote:
+		err = cmd.SetRemote(model.Local, args)
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -58,6 +58,13 @@ func main() {
 			switch args[1] {
 			case "local":
 				err = cmd.SetRemote(model.Local, args)
+			case "remote":
+				err = cmd.SetRemote(model.Remote, args) //TODO - documentation: SCP need to be enabled
+			case "git":
+				err = cmd.SetRemote(model.Git, args)
+			default:
+				log.Fatal("Invalid remote argument")
+			}
 		} else {
 			log.Fatal("Not enough arguments")
 		}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ func main() {
 	args := os.Args[1:]
 	if len(args) < 1 {
 		cmd.ShowHelp()
+		return
 	}
 
 	parsed := utils.ParseArgs(args)
@@ -33,6 +34,8 @@ func main() {
 	case model.CmdAdd:
 		if len(args) > 1 {
 			err = cmd.Add(args[1])
+		} else {
+			log.Fatal("No path specified for add")
 		}
 	case model.CmdCommit:
 		if len(args) > 1 {

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 		}
 	case model.CmdCommit:
 		if len(args) > 1 {
-			err = cmd.Commit(args[1])
+			err = cmd.Commit(args[1:])
 		} else {
 			log.Fatal("No commit message specified")
 		}

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	case model.CmdLog:
 		err = cmd.Log()
 	case model.CmdDiff:
-		err = cmd.Diff()
+		err = cmd.Diff(parsed.Verbose)
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,13 @@ func main() {
 	case model.CmdDiff:
 		err = cmd.Diff(parsed.Verbose)
 	case model.CmdSetRemote:
-		err = cmd.SetRemote(model.Local, args)
+		if len(args) >= 3 { //set-remote[0] local[1] path[2]
+			switch args[1] {
+			case "local":
+				err = cmd.SetRemote(model.Local, args)
+		} else {
+			log.Fatal("Not enough arguments")
+		}
 	case model.CmdPush:
 		err = cmd.Push()
 	}

--- a/main.go
+++ b/main.go
@@ -55,6 +55,8 @@ func main() {
 		err = cmd.Diff(parsed.Verbose)
 	case model.CmdSetRemote:
 		err = cmd.SetRemote(model.Local, args)
+	case model.CmdPush:
+		err = cmd.Push()
 	}
 
 	if err != nil {

--- a/setup-linux.sh
+++ b/setup-linux.sh
@@ -4,7 +4,7 @@ USER_HOME="$HOME"
 UTILS_DIR="$USER_HOME/utils"
 mkdir -p "$UTILS_DIR"
 
-chmod +x ./gosearch
+chmod +x ./got
 
 mv ./got "$UTILS_DIR"
 
@@ -14,4 +14,5 @@ if [[ ":$PATH:" != *":$UTILS_DIR:"* ]]; then
 else
     echo "utils is already in the PATH."
 fi
-echo "Setup ended succesfully, type got help for help"
+source "$USER_HOME/.bashrc"
+echo "Setup ended successfully, type 'got help' for help"

--- a/setup-windows.bat
+++ b/setup-windows.bat
@@ -3,7 +3,8 @@
 setlocal
 
 ::Step 1 - Compile
-go build
+echo compile
+go build -o got.exe
 
 ::Step 2 - Create utils folder in desktop if it doesn't exist
 set "UTILS_FOLDER=%USERPROFILE%\Desktop\utils"
@@ -22,14 +23,16 @@ echo Update system PATH var
 ::Define var NEW_PATH as a concatenate from old PATH with the new one
 set "NEW_PATH=%OLD_PATH%;%UTILS_FOLDER%"
 ::Add the concatenation to the registry (for PATH system var)
-::TODO check if already is
-reg add "%REG_PATH%" /v PATH /t REG_EXPAND_SZ /d "%NEW_PATH%" /f
+echo %OLD_PATH% | findstr /C:"%UTILS_FOLDER%" >nul
+if %errorlevel%==0 (
+    echo Path already contains utils folder
+) else (
+    reg add "%REG_PATH%" /v PATH /t REG_EXPAND_SZ /d "%NEW_PATH%" /f
+)
 
 ::Step 4 - Move compiled executable to utils folder
-::Move each executable to utils (should only be one)
-for %%F in (*.exe) do (
-    move "%%F" "%UTILS_FOLDER%"
-)
+move "got.exe" "%UTILS_FOLDER%"
+
 echo batch ended
-echo if 'access denied' error the exe is in Desktop/utils, either manually add it to the system PATH or restart the bat with admin right
+echo If 'access denied' error the exe is in Desktop/utils, either manually add it to the system PATH or restart the bat with admin right
 pause

--- a/unit_tests/cmd_test/add_test.go
+++ b/unit_tests/cmd_test/add_test.go
@@ -13,7 +13,7 @@ import (
 func TestAdd_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	//Create file to add
+	//Create a file to add
 	filePath := filepath.Join(tmpDir, "file.txt")
 	content := []byte("Hello World")
 	err := os.WriteFile(filePath, content, 0666)
@@ -77,11 +77,11 @@ func TestAdd_Success(t *testing.T) {
 	hash.Write(content)
 	expectedHash := hex.EncodeToString(hash.Sum(nil))
 	if records[0][1] != expectedHash {
-		t.Fatalf("Expected 'Hello World', got '%s'", records[0][0])
+		t.Fatalf("Expected hash %q, got '%s'", expectedHash, records[0][1])
 	}
 
 	if records[0][0] != "file.txt" {
-		t.Fatalf("Expected 'file.txt', got '%s'", records[0][1])
+		t.Fatalf("Expected path %s, got '%s'", "file.txt", records[0][0])
 	}
 }
 

--- a/unit_tests/cmd_test/commit_test.go
+++ b/unit_tests/cmd_test/commit_test.go
@@ -88,7 +88,8 @@ func TestCommit_Success(t *testing.T) {
 	}
 
 	//Act
-	err = cmd.Commit("My message")
+	message := []string{"my", "message"}
+	err = cmd.Commit(message)
 	if err != nil {
 		t.Fatalf("Failed to commit message: %v", err)
 	}
@@ -105,7 +106,7 @@ func TestCommit_Success(t *testing.T) {
 	//Check commits file has 1 entry
 	content, err = os.ReadFile(commitsPath)
 	lines := string(content)
-	if !strings.Contains(lines, "My message") {
+	if !strings.Contains(lines, "my message") {
 		t.Fatalf("Expected 'My message' but got '%v'", lines)
 	}
 	if err != nil {
@@ -172,7 +173,8 @@ func TestCommit_NoFolder(t *testing.T) {
 		}
 	}()
 
-	err = cmd.Commit("My message")
+	message := []string{"my", "message"}
+	err = cmd.Commit(message)
 	if err == nil {
 		t.Fatalf("Expected an error but got nil")
 	}

--- a/unit_tests/cmd_test/commit_test.go
+++ b/unit_tests/cmd_test/commit_test.go
@@ -40,10 +40,19 @@ func TestCommit_Success(t *testing.T) {
 
 	//Create .got/objects/blobs
 	err = os.MkdirAll(".got/objects/blobs", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create .got/objects/blobs directory: %v", err)
+	}
 	//Create .got/objects/commits
 	err = os.MkdirAll(".got/objects/commits", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create .got/objects/commits directory: %v", err)
+	}
 	//Create .got/objects/trees
 	err = os.MkdirAll(".got/objects/trees", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create .got/objects/trees directory: %v", err)
+	}
 
 	//Create file.txt
 	file, err := os.Create("file.txt")

--- a/unit_tests/cmd_test/diff_test.go
+++ b/unit_tests/cmd_test/diff_test.go
@@ -1,0 +1,190 @@
+package cmd_test
+
+import (
+	"bytes"
+	"github.com/joaberch/got/cmd"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiff_AddFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	err = os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to change to temp dir: %v", err)
+	}
+	defer func() {
+		err = os.Chdir(oldWd)
+		if err != nil {
+			t.Fatalf("failed to change to original dir: %v", err)
+		}
+	}()
+
+	err = cmd.Init()
+	if err != nil {
+		t.Fatalf("failed to init command: %v", err)
+	}
+
+	// Create file.txt with initial content
+	err = os.WriteFile("file.txt", []byte("Hello World1"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write file.txt: %v", err)
+	}
+
+	err = cmd.Add(filepath.Join(tmpDir, "file.txt"))
+	if err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+
+	err = cmd.Commit([]string{"initial"})
+	if err != nil {
+		t.Fatalf("failed to commit: %v", err)
+	}
+
+	err = os.WriteFile("newfile.txt", []byte("Hello World1"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write file.txt: %v", err)
+	}
+	err = cmd.Add(filepath.Join(tmpDir, "newfile.txt"))
+	if err != nil {
+		t.Fatalf("failed to add file: %v", err)
+	}
+
+	err = cmd.Diff(false)
+	if err != nil {
+		t.Fatalf("failed to diff: %v", err)
+	}
+}
+
+func TestDiff_ChangeFileSuccess(t *testing.T) {
+	tmpDir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+	err = os.Chdir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to change to temp dir: %v", err)
+	}
+	defer func() {
+		err = os.Chdir(oldWd)
+		if err != nil {
+			t.Fatalf("failed to change to original dir: %v", err)
+		}
+	}()
+
+	// Create .got structure
+	err = os.MkdirAll(".got/objects/blobs", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create blobs dir: %v", err)
+	}
+	err = os.MkdirAll(".got/objects/commits", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create commits dir: %v", err)
+	}
+	err = os.MkdirAll(".got/objects/trees", os.ModePerm)
+	if err != nil {
+		t.Fatalf("Failed to create trees dir: %v", err)
+	}
+
+	indexedPath := filepath.Join(".got", "indexed_paths.csv")
+	err = os.WriteFile(indexedPath, []byte("file.txt,abc123\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write indexed paths file: %v", err)
+	}
+
+	// Create file.txt with initial content
+	err = os.WriteFile("file.txt", []byte("Hello World"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write file.txt: %v", err)
+	}
+
+	// Simulate blob object
+	blobHash := "abc123"
+	blobPath := filepath.Join(".got", "objects", "blobs", blobHash)
+	err = os.WriteFile(blobPath, []byte("Hello World"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write blob: %v", err)
+	}
+
+	// Simulate tree object
+	treeHash := "tree123"
+	treePath := filepath.Join(".got", "objects", "trees", treeHash)
+	treeContent := `{"Entries": [{"Name": "file.txt", "Hash": "abc123"}]}`
+	err = os.WriteFile(treePath, []byte(treeContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write tree: %v", err)
+	}
+
+	// Simulate commit object
+	commitHash := "commit123"
+	commitPath := filepath.Join(".got", "objects", "commits", commitHash)
+	commitContent := `{"TreeHash": "tree123", "Message": "Initial commit"}`
+
+	err = os.WriteFile(commitPath, []byte(commitContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write commit: %v", err)
+	}
+
+	// Write head file
+	headPath := filepath.Join(".got", "head")
+	err = os.WriteFile(headPath, []byte(commitHash), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write head file: %v", err)
+	}
+
+	// Simulate index file
+	indexPath := filepath.Join(".got", "index.csv")
+	err = os.WriteFile(indexPath, []byte("file.txt,abc123\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write index file: %v", err)
+	}
+
+	// Simulate staging file
+	stagingPath := filepath.Join(".got", "staging.csv")
+	err = os.WriteFile(stagingPath, []byte("file.txt,abc123\n"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write staging file: %v", err)
+	}
+
+	// Modify file.txt to simulate a diff
+	err = os.WriteFile("file.txt", []byte("Hello Universe"), 0644)
+	if err != nil {
+		t.Fatalf("Failed to modify file.txt: %v", err)
+	}
+
+	// Capture stdout
+	var buf bytes.Buffer
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Act
+	err = cmd.Diff(false)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+
+	// Restore stdout
+	err = w.Close()
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	os.Stdout = stdout
+	_, err = buf.ReadFrom(r)
+	if err != nil {
+		t.Fatalf("Diff failed: %v", err)
+	}
+	output := buf.String()
+
+	// Assert
+	if !strings.Contains(output, "Modified file: file.txt") {
+		t.Errorf("Expected diff output for modified file, got: %s", output)
+	}
+}

--- a/unit_tests/cmd_test/init_test.go
+++ b/unit_tests/cmd_test/init_test.go
@@ -18,12 +18,11 @@ func TestInit_Success(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		err = os.Chdir(oldWd)
-		if err != nil {
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
 			t.Fatal(err)
 		}
-	}()
+	})
 
 	//FileList
 	err = cmd.Init()

--- a/unit_tests/cmd_test/log_test.go
+++ b/unit_tests/cmd_test/log_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -63,11 +64,7 @@ def456,tree2,Tester,second commit,738275835`
 
 	output := buf.String()
 
-	if !contains(output, "Commit : abc123") || !contains(output, "Commit : def456") {
+	if !strings.Contains(output, "Commit : abc123") || !strings.Contains(output, "Commit : def456") {
 		t.Fatalf("output does not contain expected commit")
 	}
-}
-
-func contains(s, substr string) bool {
-	return bytes.Contains([]byte(s), []byte(substr))
 }

--- a/unit_tests/utils_test/add_to_commits_test.go
+++ b/unit_tests/utils_test/add_to_commits_test.go
@@ -56,19 +56,11 @@ func TestAddToCommits_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	file, err := os.Open(tmpFile.Name())
+	//Check
+	_, err = tmpFile.Seek(0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
-		err = file.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	//Check
-	tmpFile.Seek(0, 0)
 	reader := csv.NewReader(tmpFile)
 	records, err := reader.ReadAll()
 	if err != nil {

--- a/unit_tests/utils_test/add_to_staging_test.go
+++ b/unit_tests/utils_test/add_to_staging_test.go
@@ -17,7 +17,7 @@ func TestAddToStaging_FileOpenError(t *testing.T) {
 	}
 	err = os.Chdir(tmpDir)
 	if err != nil {
-		return
+		t.Fatal(err)
 	}
 	defer func() {
 		err = os.Chdir(oldWd)
@@ -46,7 +46,7 @@ func TestAddToStaging_Success(t *testing.T) {
 	}
 	err = os.Chdir(tmpDir)
 	if err != nil {
-		return
+		t.Fatal(err)
 	}
 	defer func() {
 		err = os.Chdir(oldWd)

--- a/unit_tests/utils_test/clear_file_test.go
+++ b/unit_tests/utils_test/clear_file_test.go
@@ -37,6 +37,6 @@ func TestClearFile_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 	if len(content) != 0 {
-		t.Fatalf("expected empty, got %s", content)
+		t.Fatalf("expected empty, got %q", content)
 	}
 }

--- a/unit_tests/utils_test/create_blobs_test.go
+++ b/unit_tests/utils_test/create_blobs_test.go
@@ -4,17 +4,17 @@ import (
 	"github.com/joaberch/got/internal/model"
 	"github.com/joaberch/got/utils"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 )
 
 func TestCreateBlobs_ReadError(t *testing.T) {
+	base := t.TempDir()
 	tree := model.Tree{
 		Entries: []model.TreeEntry{
 			{
-				Name: "unexistent/file.txt",
-				Hash: "bolb123",
+				Name: filepath.Join(base, "nonexistent", "file.txt"),
+				Hash: "blob123",
 			},
 		},
 	}
@@ -28,7 +28,7 @@ func TestCreateBlobs_ReadError(t *testing.T) {
 func TestCreateBlobs_Success(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	filePath := path.Join(tmpDir, "file.txt")
+	filePath := filepath.Join(tmpDir, "file.txt")
 	content := []byte("this is a test file")
 	err := os.WriteFile(filePath, content, 0666)
 	if err != nil {

--- a/unit_tests/utils_test/create_file_path_test.go
+++ b/unit_tests/utils_test/create_file_path_test.go
@@ -3,13 +3,13 @@ package utils_test
 import (
 	"github.com/joaberch/got/utils"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
 func TestCreateFilePath_File(t *testing.T) {
 	tmpDir := t.TempDir()
-	filePath := path.Join(tmpDir, "file")
+	filePath := filepath.Join(tmpDir, "file")
 
 	err := utils.CreateFilePath(filePath, "File")
 	if err != nil {
@@ -27,7 +27,7 @@ func TestCreateFilePath_File(t *testing.T) {
 
 func TestCreateFilePath_Folder(t *testing.T) {
 	tmpDir := t.TempDir()
-	folderPath := path.Join(tmpDir, "nested", "folder")
+	folderPath := filepath.Join(tmpDir, "nested", "folder")
 
 	err := utils.CreateFilePath(folderPath, "Folder")
 	if err != nil {
@@ -40,5 +40,20 @@ func TestCreateFilePath_Folder(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Fatal("expected folder")
+	}
+}
+
+func TestCreateFilePath_UnknownType(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "file")
+
+	err := utils.CreateFilePath(filePath, "Unknown")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = os.Stat(filePath)
+	if err == nil {
+		t.Fatal("expected no file created")
 	}
 }

--- a/unit_tests/utils_test/deserialize_blob_test.go
+++ b/unit_tests/utils_test/deserialize_blob_test.go
@@ -1,0 +1,42 @@
+package utils
+
+import (
+	"encoding/json"
+	"github.com/joaberch/got/internal/model"
+	"github.com/joaberch/got/utils"
+	"testing"
+)
+
+func TestDeserializeBlob_Success(t *testing.T) {
+	original := model.Blob{
+		Content: []byte("This is a test"),
+	}
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("json.Marshal(original) failed: %v", err)
+	}
+
+	blob, err := utils.DeserializeBlob(data)
+	if err != nil {
+		t.Fatalf("DeserializeBlob(original) failed: %v", err)
+	}
+	if string(blob.Content) != "This is a test" {
+		t.Fatalf("Expected 'This is a test', got '%s'", string(blob.Content))
+	}
+}
+
+func TestDeserializeBlob_InvalidJSON(t *testing.T) {
+	data := []byte(`{invalid json}`)
+	_, err := utils.DeserializeBlob(data)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+}
+
+func TestDeserializeBlob_EmptyJSON(t *testing.T) {
+	data := []byte(``)
+	_, err := utils.DeserializeBlob(data)
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+}

--- a/unit_tests/utils_test/deserialize_commit_test.go
+++ b/unit_tests/utils_test/deserialize_commit_test.go
@@ -6,18 +6,11 @@ import (
 )
 
 func TestDeserializeCommit_InvalidJSON(t *testing.T) {
-	jsonData := []byte(`{<?xml version="1.0" encoding="UTF-8" ?>
- <root>
-     <TreeHash>abc123</TreeHash>
-     <Author>Tester</Author>
-     <Message>Hello World!</Message>
-     <Timestamp>1694956800</Timestamp>
- </root>
-}`)
+	jsonData := []byte(`{"TreeHash": ds, invalid, data.`)
 
 	_, err := utils.DeserializeCommit(jsonData)
 	if err == nil {
-		t.Fatal(err)
+		t.Fatal("expected error")
 	}
 }
 

--- a/unit_tests/utils_test/get_blob_from_hash_test.go
+++ b/unit_tests/utils_test/get_blob_from_hash_test.go
@@ -1,0 +1,54 @@
+package utils
+
+import (
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetBlobFromHash_Success(t *testing.T) {
+	hash := "abc123"
+	blobDir := filepath.Join(".got", "objects", "blobs")
+	blobPath := filepath.Join(blobDir, hash)
+
+	expectedContent := "This is a test blob"
+	err := os.MkdirAll(blobDir, os.ModePerm)
+	if err != nil {
+		t.Errorf("error creating directory %s: %s", blobDir, err)
+	}
+	defer func() {
+		errRemove := os.RemoveAll(".got")
+		if errRemove != nil {
+			err = errRemove
+		}
+	}()
+
+	err = os.WriteFile(blobPath, []byte(expectedContent), os.ModePerm)
+	if err != nil {
+		t.Errorf("error creating file %s: %s", blobPath, err)
+	}
+
+	blob, err := utils.GetBlobFromHash(hash)
+	if err != nil {
+		t.Errorf("error getting blob from hash %s: %s", hash, err)
+	}
+	if !(expectedContent == string(blob.Content)) {
+		t.Errorf("error getting blob from hash %s: %s", hash, err)
+	}
+	err = os.Remove(blobPath)
+	if err != nil {
+		return
+	}
+}
+
+func TestGetBlobFromHash_NoFile(t *testing.T) {
+	hash := "abc123"
+	blob, err := utils.GetBlobFromHash(hash)
+	if err == nil {
+		t.Errorf("error getting blob from hash %s: %s", hash, err)
+	}
+	if blob.Content != nil {
+		t.Errorf("error getting blob from hash %s: %s", hash, err)
+	}
+}

--- a/unit_tests/utils_test/get_commit_from_hash_test.go
+++ b/unit_tests/utils_test/get_commit_from_hash_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"github.com/joaberch/got/internal/model"
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetCommitFromHash_Success(t *testing.T) {
+	hash := "abc123"
+	commitDir := filepath.Join(".got", "objects", "commits")
+	commitPath := filepath.Join(commitDir, hash)
+	content := []byte(`{"message": "test","author":"Tester"}`)
+
+	err := os.MkdirAll(commitDir, 0755)
+	if err != nil {
+		t.Errorf("os.MkdirAll(%q, 0755) failed", commitDir)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Errorf("os.RemoveAll(%q) failed", commitDir)
+		}
+	}()
+
+	err = os.WriteFile(commitPath, content, 0644)
+	if err != nil {
+		t.Errorf("os.WriteFile(%q, content, 0644) failed", commitPath)
+	}
+
+	commit, err := utils.GetCommitFromHash(hash)
+	if err != nil {
+		t.Errorf("utils.GetCommitFromHash(%s) failed : %s", hash, commit.Message)
+	}
+	if commit.Message != "test" {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+	if commit.Author != "Tester" {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+}
+
+func TestGetCommitFromHash_NoFile(t *testing.T) {
+	hash := "abc123"
+	commit, err := utils.GetCommitFromHash(hash)
+	if err == nil {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+	if commit != (model.Commit{}) {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+}
+
+func TestGetCommitFromHash_InvalidCommit(t *testing.T) {
+	hash := "abc123"
+	commitDir := filepath.Join(".got", "objects", "commits")
+	commitPath := filepath.Join(commitDir, hash)
+	content := []byte("invalid")
+
+	err := os.MkdirAll(commitDir, 0755)
+	if err != nil {
+		t.Errorf("os.MkdirAll(%q, 0755) failed", commitDir)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Errorf("os.RemoveAll(%q) failed", commitDir)
+		}
+	}()
+
+	err = os.WriteFile(commitPath, content, 0644)
+	if err != nil {
+		t.Errorf("os.WriteFile(%q, content, 0644) failed", commitPath)
+	}
+	commit, err := utils.GetCommitFromHash(hash)
+	if err == nil {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+	if commit.Message != "" {
+		t.Errorf("utils.GetCommitFromHash(%s) failed", hash)
+	}
+}

--- a/unit_tests/utils_test/get_latest_commit_hash_test.go
+++ b/unit_tests/utils_test/get_latest_commit_hash_test.go
@@ -32,7 +32,7 @@ func TestGetLatestCommitHash_NoFile(t *testing.T) {
 }
 
 func TestGetLatestCommitHash_EmptyFile(t *testing.T) {
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	gotDir := filepath.Join(tmpDir, ".got")
 	err := os.MkdirAll(gotDir, os.ModePerm)
 	if err != nil {
@@ -77,7 +77,7 @@ func TestGetLatestCommitHash_EmptyFile(t *testing.T) {
 }
 
 func TestGetLatestCommitHash_Success(t *testing.T) {
-	tmpDir := os.TempDir()
+	tmpDir := t.TempDir()
 	gotDir := filepath.Join(tmpDir, ".got")
 	err := os.MkdirAll(gotDir, os.ModePerm)
 	if err != nil {

--- a/unit_tests/utils_test/get_staged_entries_test.go
+++ b/unit_tests/utils_test/get_staged_entries_test.go
@@ -1,0 +1,96 @@
+package utils
+
+import (
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetStagedEntries_Success(t *testing.T) {
+	stagingPath := filepath.Join(".got", "staging.csv")
+	content := []byte("file.txt,abc123\nfile.csv,def456\n")
+
+	err := os.MkdirAll(filepath.Dir(stagingPath), 0755)
+	if err != nil {
+		t.Errorf("os.MkdirAll(%q) failed", stagingPath)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Errorf("os.RemoveAll(%q) failed", stagingPath)
+		}
+	}()
+
+	err = os.WriteFile(stagingPath, content, 0644)
+	if err != nil {
+		t.Errorf("os.WriteFile(%q) failed", stagingPath)
+	}
+
+	entries, err := utils.GetStagedEntries()
+	if err != nil {
+		t.Errorf("utils.GetStagedEntries failed: %v", err)
+	}
+
+	expected := []string{"file.txt", "file.csv"}
+
+	if len(entries) != len(expected) {
+		t.Errorf("expected %d entries, got %d", len(expected), len(entries))
+	}
+	for index, entry := range entries {
+		if entry != expected[index] {
+			t.Errorf("expected entry %q, got %q", expected[index], entry)
+		}
+	}
+}
+
+func TestGetStagedEntries_NoFile(t *testing.T) {
+	err := os.RemoveAll(".got")
+	if err != nil {
+		t.Errorf("os.RemoveAll(%q) failed", filepath.Join(".got", "staging.csv"))
+	}
+
+	entries, err := utils.GetStagedEntries()
+	if err == nil {
+		t.Errorf("utils.GetStagedEntries failed: %v", err)
+	}
+	if entries != nil {
+		t.Errorf("utils.GetStagedEntries failed: %v", err)
+	}
+}
+
+func TestGetStagedEntries_Empty(t *testing.T) {
+	stagingPath := filepath.Join(".got", "staging.csv")
+	content := []byte("")
+
+	err := os.MkdirAll(filepath.Dir(stagingPath), 0755)
+	if err != nil {
+		t.Errorf("os.MkdirAll(%q) failed", stagingPath)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Errorf("os.RemoveAll(%q) failed", stagingPath)
+		}
+	}()
+
+	err = os.WriteFile(stagingPath, content, 0644)
+	if err != nil {
+		t.Errorf("os.WriteFile(%q) failed", stagingPath)
+	}
+
+	entries, err := utils.GetStagedEntries()
+	if err != nil {
+		t.Errorf("utils.GetStagedEntries failed: %v", err)
+	}
+
+	expected := []string{}
+	if len(entries) != len(expected) {
+		t.Errorf("expected %d entries, got %d", len(expected), len(entries))
+	}
+	for index, entry := range entries {
+		if entry != expected[index] {
+			t.Errorf("expected entry %q, got %q", expected[index], entry)
+		}
+	}
+}

--- a/unit_tests/utils_test/get_tree_from_commit_test.go
+++ b/unit_tests/utils_test/get_tree_from_commit_test.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"github.com/joaberch/got/internal/model"
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetTreeFromCommit_Success(t *testing.T) {
+	treeHash := "abc123"
+	treePath := filepath.Join(".got", "objects", "trees", treeHash)
+	content := []byte("{\"Entries\":[{\"Name\":\"go.mod\",\"Mode\":\"file\",\"Type\":\"blob\",\"Hash\":\"28e5edb9f5fd9dc7120bc6a423af595175f68260\"}]}")
+
+	err := os.MkdirAll(filepath.Dir(treePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating directory: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Fatalf("error removing directory: %v", err)
+		}
+	}()
+	err = os.WriteFile(treePath, content, os.ModePerm)
+	if err != nil {
+		t.Fatalf("error writing file: %v", err)
+	}
+
+	commit := model.Commit{TreeHash: treeHash}
+	tree, err := utils.GetTreeFromCommit(commit)
+	if err != nil {
+		t.Fatalf("error getting tree: %v", err)
+	}
+	if len(tree.Entries) != 1 {
+		t.Fatalf("expected tree entry 'file.txt', got %v", tree.Entries)
+	}
+}
+
+func TestGetTreeFromCommit_NoFile(t *testing.T) {
+	commit := model.Commit{TreeHash: "abc123"}
+	tree, err := utils.GetTreeFromCommit(commit)
+	if err == nil {
+		t.Fatalf("expected error getting tree")
+	}
+	if len(tree.Entries) != 0 {
+		t.Fatalf("expected tree '{}', got %v", tree)
+	}
+}
+
+func TestGetTreeFromCommit_InvalidTree(t *testing.T) {
+	treeHash := "abc123"
+	treePath := filepath.Join(".got", "objects", "trees", treeHash)
+	content := []byte("{>")
+
+	err := os.MkdirAll(filepath.Dir(treePath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating directory: %v", err)
+	}
+	err = os.WriteFile(treePath, content, os.ModePerm)
+	if err != nil {
+		t.Fatalf("error writing file: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Fatalf("error removing directory: %v", err)
+		}
+	}()
+
+	commit := model.Commit{TreeHash: treeHash}
+	tree, err := utils.GetTreeFromCommit(commit)
+	if err == nil {
+		t.Fatalf("expected error getting tree: %v", err)
+	}
+	if len(tree.Entries) != 0 {
+		t.Fatalf("expected tree entry 'file.txt', got %v", tree.Entries)
+	}
+}

--- a/unit_tests/utils_test/update_indexed_paths_test.go
+++ b/unit_tests/utils_test/update_indexed_paths_test.go
@@ -1,0 +1,166 @@
+package utils
+
+import (
+	"github.com/joaberch/got/internal/model"
+	"github.com/joaberch/got/utils"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUpdateIndexedPaths_Success(t *testing.T) {
+	indexPath := filepath.Join(".got", "indexed_paths.csv")
+	err := os.MkdirAll(filepath.Dir(indexPath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating directory: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Fatalf("error removing directory: %v", err)
+		}
+	}()
+
+	tree := model.Tree{
+		Entries: []model.TreeEntry{
+			{Name: "file.txt", Hash: "abc123"},
+			{Name: "file.csv", Hash: "def456"},
+		},
+	}
+
+	err = utils.UpdateIndexedPaths(tree)
+	if err != nil {
+		t.Fatalf("error updating indexed paths: %v", err)
+	}
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("error reading file: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	expected := map[string]string{
+		"file.txt": "abc123",
+		"file.csv": "def456",
+	}
+	if len(lines) != len(expected) {
+		t.Fatalf("expected %v lines, got %v", len(expected), len(lines))
+	}
+
+	for _, line := range lines {
+		parts := strings.Split(line, ",")
+		if len(parts) != 2 {
+			t.Errorf("expected 2 columns, got %v", len(parts))
+			continue
+		}
+		name, hash := parts[0], parts[1]
+		if expected[name] != hash {
+			t.Errorf("expected %v, got %v", expected[name], hash)
+		}
+	}
+}
+
+func TestUpdateIndexedPaths_Append(t *testing.T) {
+	indexPath := filepath.Join(".got", "indexed_paths.csv")
+	err := os.MkdirAll(filepath.Dir(indexPath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating directory: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Fatalf("error removing directory: %v", err)
+		}
+	}()
+
+	initial := []byte("file1.txt,abc123\n")
+	err = os.WriteFile(indexPath, initial, os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating file: %v", err)
+	}
+
+	tree := model.Tree{
+		Entries: []model.TreeEntry{
+			{Name: "file3.txt", Hash: "ghi789"},
+			{Name: "file2.csv", Hash: "def456"},
+		},
+	}
+
+	err = utils.UpdateIndexedPaths(tree)
+	if err != nil {
+		t.Fatalf("error updating indexed paths: %v", err)
+	}
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("error reading file: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	expected := map[string]string{
+		"file1.txt": "abc123",
+		"file3.txt": "ghi789",
+		"file2.csv": "def456",
+	}
+
+	if len(lines) != len(expected) {
+		t.Fatalf("expected %v lines, got %v", len(expected), len(lines))
+	}
+	for _, line := range lines {
+		parts := strings.Split(line, ",")
+		if len(parts) != 2 || expected[parts[0]] != parts[1] {
+			t.Errorf("expected 2 columns, got %v", len(parts))
+		}
+	}
+}
+
+func TestUpdateIndexedPaths_ExistingEntry(t *testing.T) {
+	indexPath := filepath.Join(".got", "indexed_paths.csv")
+	err := os.MkdirAll(filepath.Dir(indexPath), os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating directory: %v", err)
+	}
+	defer func() {
+		err = os.RemoveAll(".got")
+		if err != nil {
+			t.Fatalf("error removing directory: %v", err)
+		}
+	}()
+
+	initial := []byte("file1.txt,abc123\n")
+	err = os.WriteFile(indexPath, initial, os.ModePerm)
+	if err != nil {
+		t.Fatalf("error creating file: %v", err)
+	}
+	tree := model.Tree{
+		Entries: []model.TreeEntry{
+			{Name: "file1.txt", Hash: "def456"},
+		},
+	}
+
+	err = utils.UpdateIndexedPaths(tree)
+	if err != nil {
+		t.Fatalf("error updating indexed paths: %v", err)
+	}
+
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("error reading file: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	expected := map[string]string{
+		"file1.txt": "def456",
+	}
+
+	if len(lines) != len(expected) {
+		t.Fatalf("expected %v lines, got %v", len(expected), len(lines))
+	}
+	for _, line := range lines {
+		parts := strings.Split(line, ",")
+		if len(parts) != 2 || expected[parts[0]] != parts[1] {
+			t.Errorf("expected 2 columns, got %v", len(parts))
+		}
+	}
+}

--- a/unit_tests/utils_test/write_object_test.go
+++ b/unit_tests/utils_test/write_object_test.go
@@ -23,12 +23,11 @@ func TestWriteObject_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error changing working directory: %v", err)
 	}
-	defer func() {
-		err = os.Chdir(oldWd)
-		if err != nil {
-			t.Fatalf("Error changing working directory: %v", err)
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatal(err)
 		}
-	}()
+	})
 
 	content := []byte("Hello World")
 	err = utils.WriteObject("blobs", "hash123", content)
@@ -63,12 +62,11 @@ func TestWriteObject_Duplicate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error changing working directory: %v", err)
 	}
-	defer func() {
-		err = os.Chdir(oldWd)
-		if err != nil {
-			t.Fatalf("Error changing working directory: %v", err)
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Fatal(err)
 		}
-	}()
+	})
 
 	initialContent := []byte("Hello World")
 	err = utils.WriteObject("blobs", "hash123", initialContent)
@@ -89,6 +87,6 @@ func TestWriteObject_Duplicate(t *testing.T) {
 	}
 
 	if string(data) != string(initialContent) {
-		t.Fatalf("Expected %s but found %s", string(initialContent), string(newContent))
+		t.Fatalf("Expected %s but found %s", string(initialContent), string(data))
 	}
 }

--- a/utils/add_to_commits.go
+++ b/utils/add_to_commits.go
@@ -7,13 +7,6 @@ import (
 	"os"
 )
 
-// AddToCommits appends a commit record to the CSV file at the given path.
-//
-// It writes a single CSV row containing: commitHash, commit.TreeHash, commit.Author,
-// commit.Message, and commit.Timestamp (as a decimal string). commitsPath is the
-// filesystem path to the CSV file; commitHash is the commit's hash, and commit
-// supplies the remaining fields.
-//
 // AddToCommits appends a single commit record as a CSV row to the file at commitsPath.
 // 
 // The written row fields (in order) are: commitHash, commit.TreeHash, commit.Author,

--- a/utils/add_to_commits.go
+++ b/utils/add_to_commits.go
@@ -14,7 +14,13 @@ import (
 // filesystem path to the CSV file; commitHash is the commit's hash, and commit
 // supplies the remaining fields.
 //
-// On any filesystem or write error the function calls log.Fatal and terminates the process.
+// AddToCommits appends a single commit record as a CSV row to the file at commitsPath.
+// 
+// The written row fields (in order) are: commitHash, commit.TreeHash, commit.Author,
+// commit.Message, and commit.Timestamp formatted as a decimal string.
+// 
+// It returns a non-nil error if the file cannot be opened or if writing the CSV row fails.
+// Errors from closing the file are captured internally but are not propagated to the caller.
 func AddToCommits(commitsPath string, commitHash string, commit model.Commit) error {
 	file, err := os.OpenFile(commitsPath, os.O_APPEND|os.O_WRONLY, 0644)
 	if err != nil {

--- a/utils/add_to_head.go
+++ b/utils/add_to_head.go
@@ -7,7 +7,13 @@ import (
 
 // AddToHead clears the .got/head file and writes hash as the current HEAD commit hash.
 // It first empties the head file (via ClearFile) and then writes the provided hash (written as-is; no trailing newline).
-// Any error encountered while clearing, opening, writing, or closing the file causes the program to exit via log.Fatal.
+// AddToHead clears the file at headPath and writes hash as the new HEAD value.
+// 
+// AddToHead removes any existing content in headPath, opens (or creates) the file
+// with mode 0644, and writes the provided hash exactly as given (no trailing
+// newline). It returns a wrapped error if clearing the file, opening it, or
+// writing the hash fails. The function attempts to close the file when done;
+// any close error is observed but may not be propagated to the caller.
 func AddToHead(headPath string, hash string) error {
 	err := ClearFile(headPath)
 	if err != nil {

--- a/utils/add_to_head.go
+++ b/utils/add_to_head.go
@@ -5,10 +5,6 @@ import (
 	"os"
 )
 
-// AddToHead clears the .got/head file and writes hash as the current HEAD commit hash.
-// It first empties the head file (via ClearFile) and then writes the provided hash (written as-is; no trailing newline).
-// AddToHead clears the file at headPath and writes hash as the new HEAD value.
-// 
 // AddToHead removes any existing content in headPath, opens (or creates) the file
 // with mode 0644, and writes the provided hash exactly as given (no trailing
 // newline). It returns a wrapped error if clearing the file, opening it, or

--- a/utils/add_to_staging.go
+++ b/utils/add_to_staging.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 )
 
-// AddToStaging appends a CSV record to the .got/staging.csv file containing the provided
 // AddToStaging appends a CSV record [path, hash] to the .got/staging.csv file, creating the file if it does not exist.
 // 
 // It returns a non-nil error if the staging file cannot be opened or the record cannot be written. The function

--- a/utils/add_to_staging.go
+++ b/utils/add_to_staging.go
@@ -8,7 +8,11 @@ import (
 )
 
 // AddToStaging appends a CSV record to the .got/staging.csv file containing the provided
-// hash and path (written in that order). The file is created if it does not already exist.
+// AddToStaging appends a CSV record [path, hash] to the .got/staging.csv file, creating the file if it does not exist.
+// 
+// It returns a non-nil error if the staging file cannot be opened or the record cannot be written. The function
+// flushes the CSV writer and attempts to close the file; close errors are captured internally but are not reliably
+// propagated as the returned error.
 func AddToStaging(path string, hash string) error {
 	stagingPath := filepath.Join(".got", "staging.csv")
 

--- a/utils/config_local_push.go
+++ b/utils/config_local_push.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 )
 
-// ConfigLocalRemote adds the path to the .gotconfig file in the local type
-func ConfigLocalRemote(path string) error {
+// ConfigLocalPush adds the path to the .gotconfig file in the local type
+func ConfigLocalPush(path string) error {
 	remotePath := filepath.Join(".got", ".gotconfig")
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return fmt.Errorf("config Local Remote Path %s not found: %w", path, err)

--- a/utils/config_local_remote.go
+++ b/utils/config_local_remote.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigLocalRemote adds the path to the .gotconfig file in the local type
+func ConfigLocalRemote(path string) error {
+	remotePath := filepath.Join(".got", ".gotconfig")
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("config Local Remote Path %s not found: %w", path, err)
+	}
+
+	remote := map[string]string{"local": path}
+	data, err := json.MarshalIndent(remote, "", "  ")
+	if err != nil {
+		return fmt.Errorf("config Local Remote Marshal failed: %w", err)
+	}
+
+	err = os.WriteFile(remotePath, data, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("config Local Remote WriteFile failed: %w", err)
+	}
+
+	fmt.Printf("Config Local Remote WriteFile success: %s\n", path)
+	return nil
+}

--- a/utils/config_remote_push.go
+++ b/utils/config_remote_push.go
@@ -10,13 +10,24 @@ import (
 // ConfigRemotePush
 func ConfigRemotePush(ip, user, path string) error {
 	configPath := filepath.Join(".got", ".gotconfig")
+	identity := filepath.Join(os.Getenv("USERPROFILE"), ".ssh", "id_rsa")
+	identityPub := identity + ".pub"
+
+	//Generate key if not exist
+	if err := GenerateSSHKey(identity); err != nil {
+		return fmt.Errorf("failed to generate SSH key: %w", err)
+	}
+
+	if err := CopySSHKeyToRemote(identityPub, user, ip); err != nil {
+		return fmt.Errorf("failed to copy SSH key: %w", err)
+	}
 
 	remote := map[string]map[string]string{
 		"remote": {
-			"ip":   ip,
-			"user": user,
-			"path": path,
-			//"identity": filepath.Join(os.Getenv("USERPROFILE"), ".ssh", "id_rsa"),
+			"ip":       ip,
+			"user":     user,
+			"path":     path,
+			"identity": identity,
 		},
 	}
 

--- a/utils/config_remote_push.go
+++ b/utils/config_remote_push.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigRemotePush
+func ConfigRemotePush(ip, user, path string) error {
+	configPath := filepath.Join(".got", ".gotconfig")
+
+	remote := map[string]map[string]string{
+		"remote": {
+			"ip":   ip,
+			"user": user,
+			"path": path,
+			//"identity": filepath.Join(os.Getenv("USERPROFILE"), ".ssh", "id_rsa"),
+		},
+	}
+
+	data, err := json.MarshalIndent(remote, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal remote config: %w", err)
+	}
+
+	err = os.WriteFile(configPath, data, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write remote config: %w", err)
+	}
+
+	fmt.Printf("Remote config saved: %s@%s:%s in %s\n", user, ip, path, configPath)
+	return nil
+}

--- a/utils/copy_dir.go
+++ b/utils/copy_dir.go
@@ -1,0 +1,29 @@
+package utils
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CopyDir copy the dir given to the destination
+func CopyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		targetPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(targetPath, data, info.Mode())
+	})
+}

--- a/utils/copy_file.go
+++ b/utils/copy_file.go
@@ -1,0 +1,12 @@
+package utils
+
+import "os"
+
+// CopyFile copy the file from the source to the destination
+func CopyFile(src, dst string) error {
+	input, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, input, 0644)
+}

--- a/utils/copy_ssh_key_to_remote.go
+++ b/utils/copy_ssh_key_to_remote.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func CopySSHKeyToRemote(identityPubPath, user, ip string) error {
+	cmd := exec.Command("ssh", fmt.Sprintf("%s@%s", user, ip),
+		"mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys")
+	pubKey, err := os.ReadFile(identityPubPath)
+	if err != nil {
+		return fmt.Errorf("failed to read public key from %s: %w", identityPubPath, err)
+	}
+	cmd.Stdin = bytes.NewBuffer(pubKey)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/utils/create_blobs.go
+++ b/utils/create_blobs.go
@@ -6,9 +6,6 @@ import (
 	"os"
 )
 
-// CreateBlobs reads each file referenced by tree.Entries and writes its content as a blob object named by the entry's Hash into the objects/blobs store.
-// If reading or writing any entry fails, the function logs the error and exits the program.
-// CreateBlobs reads each entry in the tree and stores its file contents as a blob.
 // CreateBlobs reads the file at entry.Name and writes its contents to the "blobs" object store using entry.Hash as the object name.
 // It returns a wrapped error if any file read or object write fails; on success it returns nil.
 func CreateBlobs(tree model.Tree) error {

--- a/utils/create_blobs.go
+++ b/utils/create_blobs.go
@@ -8,7 +8,9 @@ import (
 
 // CreateBlobs reads each file referenced by tree.Entries and writes its content as a blob object named by the entry's Hash into the objects/blobs store.
 // If reading or writing any entry fails, the function logs the error and exits the program.
-// Each entry is expected to provide Name (filesystem path) and Hash (blob identifier).
+// CreateBlobs reads each entry in the tree and stores its file contents as a blob.
+// CreateBlobs reads the file at entry.Name and writes its contents to the "blobs" object store using entry.Hash as the object name.
+// It returns a wrapped error if any file read or object write fails; on success it returns nil.
 func CreateBlobs(tree model.Tree) error {
 	for _, entry := range tree.Entries {
 		//entry.Name = path to real file

--- a/utils/create_blobs.go
+++ b/utils/create_blobs.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"fmt"
 	"github.com/joaberch/got/internal/model"
-	"os"
 )
+
+//TODO - mkdir the blobs dir?
 
 // CreateBlobs reads the file at entry.Name and writes its contents to the "blobs" object store using entry.Hash as the object name.
 // It returns a wrapped error if any file read or object write fails; on success it returns nil.
@@ -12,14 +13,14 @@ func CreateBlobs(tree model.Tree) error {
 	for _, entry := range tree.Entries {
 		//entry.Name = path to real file
 		//entry.Hash = blob name to create (file name)
-		content, err := os.ReadFile(entry.Name)
+		content, err := GetFileContent(entry.Name)
 		if err != nil {
 			return fmt.Errorf("failed to read file at %s: %w", entry.Name, err)
 		}
 
 		err = WriteObject("blobs", entry.Hash, content)
 		if err != nil {
-			return fmt.Errorf("failed to write to blobs file at %s: %w", entry.Name, err)
+			return fmt.Errorf("failed to write to blobs %s %s: %w", entry.Name, entry.Hash, err)
 		}
 	}
 	return nil

--- a/utils/create_blobs.go
+++ b/utils/create_blobs.go
@@ -5,8 +5,6 @@ import (
 	"github.com/joaberch/got/internal/model"
 )
 
-//TODO - mkdir the blobs dir?
-
 // CreateBlobs reads the file at entry.Name and writes its contents to the "blobs" object store using entry.Hash as the object name.
 // It returns a wrapped error if any file read or object write fails; on success it returns nil.
 func CreateBlobs(tree model.Tree) error {

--- a/utils/create_file_path.go
+++ b/utils/create_file_path.go
@@ -6,12 +6,6 @@ import (
 	"path/filepath"
 )
 
-// CreateFilePath creates a directory or file at the given path.
-//
-// If fileType is "Folder", it creates the directory tree rooted at fullPath.
-// If fileType is "File", it ensures the parent directory exists and creates an empty file at fullPath.
-// For any other fileType value the function does nothing.
-//
 // CreateFilePath creates filesystem entries at fullPath according to fileType.
 // 
 // If fileType == "Folder", it creates the directory tree at fullPath (mkdir -p semantics).

--- a/utils/create_file_path.go
+++ b/utils/create_file_path.go
@@ -12,7 +12,14 @@ import (
 // If fileType is "File", it ensures the parent directory exists and creates an empty file at fullPath.
 // For any other fileType value the function does nothing.
 //
-// Any filesystem error is fatal: the function calls log.Fatal on failure, terminating the program.
+// CreateFilePath creates filesystem entries at fullPath according to fileType.
+// 
+// If fileType == "Folder", it creates the directory tree at fullPath (mkdir -p semantics).
+// If fileType == "File", it ensures the parent directory exists and creates an empty file at fullPath.
+// For any other fileType value the function does nothing.
+// 
+// On failure the function returns a non-nil error describing the filesystem error (directory creation,
+// file creation, or file close failure). On success it returns nil.
 func CreateFilePath(fullPath string, fileType string) error {
 	const dirPerm = 0755
 

--- a/utils/create_file_path.go
+++ b/utils/create_file_path.go
@@ -6,14 +6,13 @@ import (
 	"path/filepath"
 )
 
-// CreateFilePath creates filesystem entries at fullPath according to fileType.
-// 
-// If fileType == "Folder", it creates the directory tree at fullPath (mkdir -p semantics).
-// If fileType == "File", it ensures the parent directory exists and creates an empty file at fullPath.
-// For any other fileType value the function does nothing.
-// 
-// On failure the function returns a non-nil error describing the filesystem error (directory creation,
-// file creation, or file close failure). On success it returns nil.
+// CreateFilePath creates a directory or file at the given path.
+//
+// If fileType is "Folder", it creates the directory tree rooted at fullPath.
+// If fileType is "File", it ensures the parent directory exists and creates an empty file at fullPath.
+// For any other fileType value, the function does nothing.
+//
+// Returns an error if any filesystem operation fails.
 func CreateFilePath(fullPath string, fileType string) error {
 	const dirPerm = 0755
 

--- a/utils/deserialize_blob.go
+++ b/utils/deserialize_blob.go
@@ -5,6 +5,9 @@ import (
 	"github.com/joaberch/got/internal/model"
 )
 
+// DeserializeBlob parses JSON-encoded data into a model.Blob.
+// The input `data` should contain JSON representing a Blob; the function
+// returns the parsed Blob and any error produced by json.Unmarshal.
 func DeserializeBlob(data []byte) (model.Blob, error) {
 	var blob model.Blob
 	err := json.Unmarshal(data, &blob)

--- a/utils/deserialize_commit.go
+++ b/utils/deserialize_commit.go
@@ -7,7 +7,12 @@ import (
 
 // DeserializeCommit deserializes JSON-encoded data into a model.Commit and returns
 // a pointer to the resulting Commit along with any error produced by json.Unmarshal.
-// The function does no additional validation of the decoded value.
+// DeserializeCommit deserializes JSON-encoded data into a model.Commit.
+// 
+// The input `data` must contain a JSON representation of model.Commit. The
+// function returns the decoded Commit value and any error from json.Unmarshal.
+// No additional validation is performed; on error the returned Commit is the
+// zero value for model.Commit.
 func DeserializeCommit(data []byte) (model.Commit, error) {
 	var commit model.Commit
 	err := json.Unmarshal(data, &commit)

--- a/utils/deserialize_commit.go
+++ b/utils/deserialize_commit.go
@@ -5,8 +5,6 @@ import (
 	"github.com/joaberch/got/internal/model"
 )
 
-// DeserializeCommit deserializes JSON-encoded data into a model.Commit and returns
-// a pointer to the resulting Commit along with any error produced by json.Unmarshal.
 // DeserializeCommit deserializes JSON-encoded data into a model.Commit.
 // 
 // The input `data` must contain a JSON representation of model.Commit. The

--- a/utils/deserialize_tree.go
+++ b/utils/deserialize_tree.go
@@ -7,7 +7,10 @@ import (
 
 // DeserializeTree unmarshals JSON-encoded data into a model.Tree and returns a pointer to it.
 // The input data must contain a JSON representation of a model.Tree. If unmarshalling fails,
-// the returned error describes the failure and the returned *model.Tree will be the zero-value instance.
+// DeserializeTree decodes JSON-encoded data into a model.Tree.
+// If decoding succeeds it returns the populated Tree and a nil error.
+// On failure it returns the zero-value Tree and the decoding error.
+// The input must be JSON representing a model.Tree.
 func DeserializeTree(data []byte) (model.Tree, error) {
 	var tree model.Tree
 	err := json.Unmarshal(data, &tree)

--- a/utils/deserialize_tree.go
+++ b/utils/deserialize_tree.go
@@ -5,8 +5,6 @@ import (
 	"github.com/joaberch/got/internal/model"
 )
 
-// DeserializeTree unmarshals JSON-encoded data into a model.Tree and returns a pointer to it.
-// The input data must contain a JSON representation of a model.Tree. If unmarshalling fails,
 // DeserializeTree decodes JSON-encoded data into a model.Tree.
 // If decoding succeeds it returns the populated Tree and a nil error.
 // On failure it returns the zero-value Tree and the decoding error.

--- a/utils/deserialize_tree.go
+++ b/utils/deserialize_tree.go
@@ -6,8 +6,8 @@ import (
 )
 
 // DeserializeTree decodes JSON-encoded data into a model.Tree.
-// If decoding succeeds it returns the populated Tree and a nil error.
-// On failure it returns the zero-value Tree and the decoding error.
+// If decoding succeeds, it returns the populated Tree and a nil error.
+// On failure, it returns the zero-value Tree and the decoding error.
 // The input must be JSON representing a model.Tree.
 func DeserializeTree(data []byte) (model.Tree, error) {
 	var tree model.Tree

--- a/utils/generate_ssh_key.go
+++ b/utils/generate_ssh_key.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func GenerateSSHKey(identityPath string) error {
+	if _, err := os.Stat(identityPath); os.IsNotExist(err) {
+		cmd := exec.Command("ssh-keygen", "-t", "rsa", "-b", "4096", "-f", identityPath, "-N", "")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	}
+
+	return fmt.Errorf("SSH key already exists: %s", identityPath)
+}

--- a/utils/get_blob_from_hash.go
+++ b/utils/get_blob_from_hash.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 )
 
+// GetBlobFromHash reads the blob file for the given hash from ".got/objects/blobs" and returns it as a model.Blob.
+// The hash is treated as the blob filename; on success the Blob's Content contains the file bytes.
+// Returns a non-nil error if the blob file cannot be read.
 func GetBlobFromHash(hash string) (model.Blob, error) {
 	blobPath := filepath.Join(".got", "objects", "blobs", hash)
 	data, err := os.ReadFile(blobPath)

--- a/utils/get_blob_from_hash.go
+++ b/utils/get_blob_from_hash.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"github.com/joaberch/got/internal/model"
-	"os"
 	"path/filepath"
 )
 
@@ -12,9 +11,9 @@ import (
 // Returns a non-nil error if the blob file cannot be read.
 func GetBlobFromHash(hash string) (model.Blob, error) {
 	blobPath := filepath.Join(".got", "objects", "blobs", hash)
-	data, err := os.ReadFile(blobPath)
+	data, err := GetFileContent(blobPath)
 	if err != nil {
-		return model.Blob{}, fmt.Errorf("error reading blob file %s: %s", blobPath, err)
+		return model.Blob{}, fmt.Errorf("error reading blob file %s: %w", blobPath, err)
 	}
 	return model.Blob{Content: data}, nil
 }

--- a/utils/get_commit_from_hash.go
+++ b/utils/get_commit_from_hash.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 )
 
+// GetCommitFromHash returns the Commit object stored at .got/objects/commits/{hash}.
+// It reads the commit file for the provided hash and deserializes its contents.
+// Returns an error if the file cannot be read or if deserialization fails.
 func GetCommitFromHash(hash string) (model.Commit, error) {
 	commitPath := filepath.Join(".got", "objects", "commits", hash)
 	data, err := os.ReadFile(commitPath)

--- a/utils/get_commit_from_hash.go
+++ b/utils/get_commit_from_hash.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"github.com/joaberch/got/internal/model"
-	"os"
 	"path/filepath"
 )
 
@@ -12,13 +11,13 @@ import (
 // Returns an error if the file cannot be read or if deserialization fails.
 func GetCommitFromHash(hash string) (model.Commit, error) {
 	commitPath := filepath.Join(".got", "objects", "commits", hash)
-	data, err := os.ReadFile(commitPath)
+	data, err := GetFileContent(commitPath)
 	if err != nil {
-		return model.Commit{}, fmt.Errorf("error reading commit file a commit needs to be done first to see the differences %s: %s", commitPath, err)
+		return model.Commit{}, fmt.Errorf("error reading commit %s: %w", commitPath, err)
 	}
 	commit, err := DeserializeCommit(data)
 	if err != nil {
-		return model.Commit{}, fmt.Errorf("error parsing commit file %s: %s", commitPath, err)
+		return model.Commit{}, fmt.Errorf("error parsing commit file %s: %w", commitPath, err)
 	}
 	return commit, nil
 }

--- a/utils/get_file_content.go
+++ b/utils/get_file_content.go
@@ -7,7 +7,7 @@ import (
 
 // GetFileContent reads and returns the contents of the file at the given path.
 // If the file cannot be read the function logs the error and calls log.Fatal,
-// causing the program to exit.
+// includes the file path.
 func GetFileContent(path string) ([]byte, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {

--- a/utils/get_file_content.go
+++ b/utils/get_file_content.go
@@ -2,12 +2,13 @@ package utils
 
 import (
 	"fmt"
+	"os"
 )
 
 // GetFileContent reads and returns the contents of the file at the given path.
 // If the file cannot be read, the function returns an error with context.
 func GetFileContent(path string) ([]byte, error) {
-	contents, err := GetFileContent(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file at %s: %w", path, err)
 	}

--- a/utils/get_file_content.go
+++ b/utils/get_file_content.go
@@ -2,14 +2,12 @@ package utils
 
 import (
 	"fmt"
-	"os"
 )
 
 // GetFileContent reads and returns the contents of the file at the given path.
-// If the file cannot be read the function logs the error and calls log.Fatal,
-// includes the file path.
+// If the file cannot be read, the function returns an error with context.
 func GetFileContent(path string) ([]byte, error) {
-	contents, err := os.ReadFile(path)
+	contents, err := GetFileContent(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file at %s: %w", path, err)
 	}

--- a/utils/get_indexed_paths.go
+++ b/utils/get_indexed_paths.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func GetIndexedPathsWithHash() (map[string]string, error) {
+	indexPath := filepath.Join(".got", "indexed_paths.csv")
+	file, err := os.Open(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening indexed path: %s", err)
+	}
+	defer func() {
+		errClose := file.Close()
+		if errClose != nil {
+			err = errClose
+		}
+	}()
+
+	paths := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, ",")
+		if len(parts) == 2 {
+			paths[parts[0]] = parts[1]
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading indexed paths: %s", err)
+	}
+	return paths, nil
+}

--- a/utils/get_indexed_paths_with_hash.go
+++ b/utils/get_indexed_paths_with_hash.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 )
 
+// GetIndexedPathsWithHash returns a map of each file processed with their latest hash
 func GetIndexedPathsWithHash() (map[string]string, error) {
 	indexPath := filepath.Join(".got", "indexed_paths.csv")
 	file, err := os.Open(indexPath)

--- a/utils/get_latest_commit_hash.go
+++ b/utils/get_latest_commit_hash.go
@@ -9,7 +9,10 @@ import (
 // GetLatestCommitHash reads the file ".got/head" and returns its entire contents as a string.
 // Each line in the file is appended with a trailing newline in the returned value.
 // If the file cannot be opened or closed, the function logs the error and exits the process via log.Fatal.
-// If the file is empty, an empty string is returned.
+// GetLatestCommitHash reads the repository head file at ".got/head" and returns its contents
+// with surrounding whitespace trimmed.
+// It returns the trimmed commit hash and any error encountered while reading the file.
+// If the file is empty or contains only whitespace, an empty string is returned.
 func GetLatestCommitHash() (string, error) {
 	headPath := filepath.Join(".got", "head")
 	data, err := os.ReadFile(headPath)

--- a/utils/get_latest_commit_hash.go
+++ b/utils/get_latest_commit_hash.go
@@ -6,9 +6,6 @@ import (
 	"strings"
 )
 
-// GetLatestCommitHash reads the file ".got/head" and returns its entire contents as a string.
-// Each line in the file is appended with a trailing newline in the returned value.
-// If the file cannot be opened or closed, the function logs the error and exits the process via log.Fatal.
 // GetLatestCommitHash reads the repository head file at ".got/head" and returns its contents
 // with surrounding whitespace trimmed.
 // It returns the trimmed commit hash and any error encountered while reading the file.

--- a/utils/get_latest_commit_hash.go
+++ b/utils/get_latest_commit_hash.go
@@ -1,18 +1,16 @@
 package utils
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 )
 
-// GetLatestCommitHash reads the repository head file at ".got/head" and returns its contents
-// with surrounding whitespace trimmed.
-// It returns the trimmed commit hash and any error encountered while reading the file.
-// If the file is empty or contains only whitespace, an empty string is returned.
+// GetLatestCommitHash reads the file ".got/head" and returns its contents as a trimmed string.
+// If the file cannot be read, an error is returned.
+// If the file is empty, an empty string is returned with no error.
 func GetLatestCommitHash() (string, error) {
 	headPath := filepath.Join(".got", "head")
-	data, err := os.ReadFile(headPath)
+	data, err := GetFileContent(headPath)
 	if err != nil {
 		return "", err
 	}

--- a/utils/get_staged_entries.go
+++ b/utils/get_staged_entries.go
@@ -1,0 +1,40 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// GetStagedEntries fetch the relative path of the files added to the staging area
+func GetStagedEntries() ([]string, error) {
+	stagingPath := filepath.Join(".got", "staging.csv")
+	file, err := os.Open(stagingPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening staging file: %v", err)
+	}
+	defer func() {
+		err = file.Close()
+		if err != nil {
+			fmt.Printf("error closing staging file: %v", err)
+		}
+	}()
+
+	var entries []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, ",")
+		if len(parts) >= 1 {
+			entries = append(entries, parts[0])
+		}
+	}
+
+	if err = scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading staging file: %v", err)
+	}
+
+	return entries, nil
+}

--- a/utils/get_tree_from_commit.go
+++ b/utils/get_tree_from_commit.go
@@ -7,6 +7,12 @@ import (
 	"path/filepath"
 )
 
+// GetTreeFromCommit reads and parses the tree object referenced by the given commit.
+// 
+// GetTreeFromCommit looks up the tree file at ".got/objects/trees/<commit.TreeHash>", reads
+// its contents and deserializes them with DeserializeTree. It returns the parsed model.Tree on
+// success. If the file cannot be read or the data cannot be parsed, it returns an empty
+// model.Tree and a non-nil error describing the failure.
 func GetTreeFromCommit(commit model.Commit) (model.Tree, error) {
 	treePath := filepath.Join(".got", "objects", "trees", commit.TreeHash)
 	data, err := os.ReadFile(treePath)

--- a/utils/get_tree_from_commit.go
+++ b/utils/get_tree_from_commit.go
@@ -3,25 +3,24 @@ package utils
 import (
 	"fmt"
 	"github.com/joaberch/got/internal/model"
-	"os"
 	"path/filepath"
 )
 
 // GetTreeFromCommit reads and parses the tree object referenced by the given commit.
-// 
+//
 // GetTreeFromCommit looks up the tree file at ".got/objects/trees/<commit.TreeHash>", reads
 // its contents and deserializes them with DeserializeTree. It returns the parsed model.Tree on
 // success. If the file cannot be read or the data cannot be parsed, it returns an empty
 // model.Tree and a non-nil error describing the failure.
 func GetTreeFromCommit(commit model.Commit) (model.Tree, error) {
 	treePath := filepath.Join(".got", "objects", "trees", commit.TreeHash)
-	data, err := os.ReadFile(treePath)
+	data, err := GetFileContent(treePath)
 	if err != nil {
-		return model.Tree{}, fmt.Errorf("error reading tree file %s: %s", treePath, err)
+		return model.Tree{}, fmt.Errorf("error reading tree file %s: %w", treePath, err)
 	}
 	tree, err := DeserializeTree(data)
 	if err != nil {
-		return model.Tree{}, fmt.Errorf("error parsing tree file %s: %s", treePath, err)
+		return model.Tree{}, fmt.Errorf("error parsing tree file %s: %w", treePath, err)
 	}
 	return tree, nil
 }

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -8,7 +8,21 @@ import "github.com/joaberch/got/internal/model"
 // Supported tokens (short and long forms): "help"/"h", "version"/"v",
 // "init"/"i", "add"/"a", "commit"/"c", "restore"/"r". Unrecognized tokens are
 // ignored; if no supported token is found, the returned ParsedArgs has
-// Command == model.CmdNone.
+// ParseArgs parses a slice of argument tokens and returns a model.ParsedArgs
+// whose Command field is set to the last recognized command token.
+//
+// It recognizes short and long forms for commands:
+// - "help" or "h" -> model.CmdHelp
+// - "version" or "v" -> model.CmdVersion
+// - "init" or "i" -> model.CmdInit
+// - "add" or "a" -> model.CmdAdd
+// - "commit" or "c" -> model.CmdCommit
+// - "restore" or "r" -> model.CmdRestore
+// - "log" or "l" -> model.CmdLog
+// - "diff" or "d" -> model.CmdDiff
+//
+// Unrecognized tokens are ignored; if no supported token is found the returned
+// ParsedArgs.Command remains model.CmdNone.
 func ParseArgs(args []string) model.ParsedArgs {
 	parsed := model.ParsedArgs{
 		Command: model.CmdNone,

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -31,21 +31,21 @@ func ParseArgs(args []string) model.ParsedArgs {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch arg {
-		case "help", "h":
+		case "help":
 			parsed.Command = model.CmdHelp
-		case "version", "v":
+		case "version":
 			parsed.Command = model.CmdVersion
-		case "init", "i":
+		case "init":
 			parsed.Command = model.CmdInit
-		case "add", "a":
+		case "add":
 			parsed.Command = model.CmdAdd
-		case "commit", "c":
+		case "commit":
 			parsed.Command = model.CmdCommit
-		case "restore", "r":
+		case "restore":
 			parsed.Command = model.CmdRestore
-		case "log", "l":
+		case "log":
 			parsed.Command = model.CmdLog
-		case "diff", "d":
+		case "diff":
 			parsed.Command = model.CmdDiff
 		}
 	}

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -11,15 +11,15 @@ import "github.com/joaberch/got/internal/model"
 // ParseArgs parses a slice of argument tokens and returns a model.ParsedArgs
 // whose Command field is set to the last recognized command token.
 //
-// It recognizes short and long forms for commands:
-// - "help" or "h" -> model.CmdHelp
-// - "version" or "v" -> model.CmdVersion
-// - "init" or "i" -> model.CmdInit
-// - "add" or "a" -> model.CmdAdd
-// - "commit" or "c" -> model.CmdCommit
-// - "restore" or "r" -> model.CmdRestore
-// - "log" or "l" -> model.CmdLog
-// - "diff" or "d" -> model.CmdDiff
+// It recognizes long forms for commands:
+// - "help" -> model.CmdHelp
+// - "version" -> model.CmdVersion
+// - "init" -> model.CmdInit
+// - "add" -> model.CmdAdd
+// - "commit" -> model.CmdCommit
+// - "restore" -> model.CmdRestore
+// - "log" -> model.CmdLog
+// - "diff" -> model.CmdDiff
 //
 // Unrecognized tokens are ignored; if no supported token is found the returned
 // ParsedArgs.Command remains model.CmdNone.

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -49,6 +49,8 @@ func ParseArgs(args []string) model.ParsedArgs {
 			parsed.Command = model.CmdDiff
 		case "set-remote", "setRemote":
 			parsed.Command = model.CmdSetRemote
+		case "push":
+			parsed.Command = model.CmdPush
 		case "-v":
 			parsed.Verbose = true
 		}

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -29,30 +29,46 @@ func ParseArgs(args []string) model.ParsedArgs {
 		Verbose: false,
 	}
 
+	//flags
+	for _, arg := range args {
+		switch arg {
+		case "-v":
+			parsed.Verbose = true
+		}
+	}
+
 	for _, arg := range args {
 		switch arg {
 		case "help":
 			parsed.Command = model.CmdHelp
+			return parsed
 		case "version":
 			parsed.Command = model.CmdVersion
+			return parsed
 		case "init":
 			parsed.Command = model.CmdInit
+			return parsed
 		case "add":
 			parsed.Command = model.CmdAdd
+			return parsed
 		case "commit":
 			parsed.Command = model.CmdCommit
+			return parsed
 		case "restore":
 			parsed.Command = model.CmdRestore
+			return parsed
 		case "log":
 			parsed.Command = model.CmdLog
+			return parsed
 		case "diff":
 			parsed.Command = model.CmdDiff
+			return parsed
 		case "set-remote", "setRemote":
 			parsed.Command = model.CmdSetRemote
+			return parsed
 		case "push":
 			parsed.Command = model.CmdPush
-		case "-v":
-			parsed.Verbose = true
+			return parsed
 		}
 	}
 

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -47,6 +47,8 @@ func ParseArgs(args []string) model.ParsedArgs {
 			parsed.Command = model.CmdLog
 		case "diff":
 			parsed.Command = model.CmdDiff
+		case "set-remote", "setRemote":
+			parsed.Command = model.CmdSetRemote
 		case "-v":
 			parsed.Verbose = true
 		}

--- a/utils/parse_args.go
+++ b/utils/parse_args.go
@@ -26,10 +26,10 @@ import "github.com/joaberch/got/internal/model"
 func ParseArgs(args []string) model.ParsedArgs {
 	parsed := model.ParsedArgs{
 		Command: model.CmdNone,
+		Verbose: false,
 	}
 
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
+	for _, arg := range args {
 		switch arg {
 		case "help":
 			parsed.Command = model.CmdHelp
@@ -47,6 +47,8 @@ func ParseArgs(args []string) model.ParsedArgs {
 			parsed.Command = model.CmdLog
 		case "diff":
 			parsed.Command = model.CmdDiff
+		case "-v":
+			parsed.Verbose = true
 		}
 	}
 

--- a/utils/push_local.go
+++ b/utils/push_local.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func PushLocal(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("remote path does not exist: %s", path)
+	}
+
+	err := CopyDir(".got/objects", filepath.Join(path, "objects"))
+	if err != nil {
+		return fmt.Errorf("error copying remote objects: %w", err)
+	}
+
+	files := []string{"commits.csv", "head"}
+	for _, file := range files {
+		src := filepath.Join(".got", file)
+		dst := filepath.Join(path, file)
+
+		err = CopyFile(src, dst)
+		if err != nil {
+			return fmt.Errorf("error copying remote objects: %w", err)
+		}
+	}
+
+	fmt.Println("Pushed remote objects to:", path)
+	return nil
+}

--- a/utils/push_remote.go
+++ b/utils/push_remote.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func PushRemote(ip, user, path, identityPath string) error {
+	cmd := exec.Command("scp" /*"-i", identityPath,*/, "-r", ".got/objects", fmt.Sprintf("%s@%s:%s", user, ip, path))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to push remote objects: %w", err)
+	}
+
+	for _, file := range []string{"commits.csv", "head"} { //The other files than objects to copy
+		src := filepath.Join(".got", file)
+		dst := fmt.Sprintf("%s@%s:%s/%s", user, ip, path, file)
+		cmd = exec.Command("scp", src, dst)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to push remote objects: %w", err)
+		}
+	}
+	fmt.Printf("pushed remote objects: %s\n", path)
+	return nil
+}

--- a/utils/read_staging_file.go
+++ b/utils/read_staging_file.go
@@ -13,7 +13,15 @@ import (
 // If the file cannot be opened or the CSV cannot be read, the function calls log.Fatal and terminates the program.
 //
 // record[0] = path ro real file to include in the commit
-// record[1] = blob name (hash) can be fictive
+// ReadStagingFile reads a two-column CSV from path and builds a model.Tree.
+//
+// The CSV is expected to have the file path in column 0 and the blob/hash in column 1.
+// Each row with at least two fields produces a TreeEntry with Name set to the file path,
+// Hash set to the blob name, Mode set to "file", and Type set to "blob". Rows with
+// fewer than two fields are skipped.
+//
+// Returns a non-nil error if opening or reading the file fails. Any error encountered
+// when closing the file is recorded in the deferred close but is not propagated to the caller.
 
 func ReadStagingFile(path string) (model.Tree, error) {
 	tree := model.Tree{}

--- a/utils/read_staging_file.go
+++ b/utils/read_staging_file.go
@@ -8,7 +8,7 @@ import (
 )
 
 // ReadStagingFile reads a two-column CSV at the given path and returns a model.Tree representing the staging area.
-// Each CSV record is expected to have at least two fields: the object hash at index 0 and the file path at index 1.
+// Each CSV record is expected to have at least two fields: the file path at index 0 and the index hash at index 1.
 // For each record a model.TreeEntry is appended with Name set to the path, Hash set to the hash, Mode "file", and Type "blob".
 // If the file cannot be opened or the CSV cannot be read, the function calls log.Fatal and terminates the program.
 //
@@ -33,7 +33,7 @@ func ReadStagingFile(path string) (model.Tree, error) {
 	defer func(file *os.File) {
 		errClose := file.Close()
 		if errClose != nil {
-			err = fmt.Errorf("failed to close file: %w", errClose)
+			err = errClose
 		}
 	}(file)
 

--- a/utils/show_line_diff.go
+++ b/utils/show_line_diff.go
@@ -5,6 +5,11 @@ import (
 	"strings"
 )
 
+// ShowLineDiff prints a color-coded, line-by-line diff between two multi-line strings.
+// It splits both inputs on '\n' and compares corresponding lines; when lines differ it
+// prints the old line (removal) in red prefixed with " - " and the new line (addition)
+// in green prefixed with " + ". Line numbers are 1-based. Identical lines are omitted.
+// The function writes directly to stdout using ANSI color codes and does not return any value.
 func ShowLineDiff(old string, new string) {
 	oldLines := strings.Split(old, "\n")
 	newLines := strings.Split(new, "\n")

--- a/utils/show_line_diff.go
+++ b/utils/show_line_diff.go
@@ -30,8 +30,9 @@ func ShowLineDiff(old string, new string) {
 				fmt.Printf("\033[31m [%d] - %s\033[0m\n", i+1, oldLine)
 			}
 			if newLine != "" {
-				fmt.Printf("\033[32m [%d] + %s\033[0m\n\n", i+1, newLine)
+				fmt.Printf("\033[32m [%d] + %s\033[0m\n", i+1, newLine)
 			}
 		}
 	}
+	fmt.Println()
 }

--- a/utils/update_indexed_paths.go
+++ b/utils/update_indexed_paths.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/joaberch/got/internal/model"
+	"os"
+	"path/filepath"
+)
+
+// UpdateIndexedPaths appends the distinct file from the tree in the 'indexed_paths.csv'
+func UpdateIndexedPaths(tree model.Tree) error {
+	indexPath := filepath.Join(".got", "indexed_paths.csv")
+
+	//Get the already indexed
+	existing := make(map[string]bool)
+	if _, err := os.Stat(indexPath); err == nil {
+		file, err := os.Open(indexPath)
+		if err != nil {
+			return fmt.Errorf("error opening indexed path: %s", err)
+		}
+		defer func() {
+			closeErr := file.Close()
+			if closeErr != nil {
+				err = closeErr
+			}
+		}()
+
+		scanner := bufio.NewScanner(file)
+		for scanner.Scan() {
+			existing[scanner.Text()] = true
+		}
+	}
+
+	file, err := os.OpenFile(indexPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("error opening indexed path: %s", err)
+	}
+	defer func() {
+		closeErr := file.Close()
+		if closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	writer := bufio.NewWriter(file)
+	for _, entry := range tree.Entries {
+		if !existing[entry.Name] {
+			_, err = writer.WriteString(entry.Name + "\n")
+			if err != nil {
+				return fmt.Errorf("error writing to indexed path: %s", err)
+			}
+		}
+	}
+	return writer.Flush()
+}

--- a/utils/update_indexed_paths.go
+++ b/utils/update_indexed_paths.go
@@ -6,6 +6,7 @@ import (
 	"github.com/joaberch/got/internal/model"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // UpdateIndexedPaths appends the distinct file from the tree in the 'indexed_paths.csv'
@@ -13,7 +14,7 @@ func UpdateIndexedPaths(tree model.Tree) error {
 	indexPath := filepath.Join(".got", "indexed_paths.csv")
 
 	//Get the already indexed
-	existing := make(map[string]bool)
+	existing := make(map[string]string)
 	if _, err := os.Stat(indexPath); err == nil {
 		file, err := os.Open(indexPath)
 		if err != nil {
@@ -28,11 +29,18 @@ func UpdateIndexedPaths(tree model.Tree) error {
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			existing[scanner.Text()] = true
+			parts := strings.Split(scanner.Text(), ",")
+			if len(parts) == 2 {
+				existing[parts[0]] = parts[1]
+			}
 		}
 	}
 
-	file, err := os.OpenFile(indexPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	for _, entry := range tree.Entries {
+		existing[entry.Name] = entry.Hash
+	}
+
+	file, err := os.OpenFile(indexPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
 		return fmt.Errorf("error opening indexed path: %s", err)
 	}
@@ -44,12 +52,10 @@ func UpdateIndexedPaths(tree model.Tree) error {
 	}()
 
 	writer := bufio.NewWriter(file)
-	for _, entry := range tree.Entries {
-		if !existing[entry.Name] {
-			_, err = writer.WriteString(entry.Name + "\n")
-			if err != nil {
-				return fmt.Errorf("error writing to indexed path: %s", err)
-			}
+	for name, hash := range existing {
+		_, err := writer.WriteString(fmt.Sprintf("%s,%s\n", name, hash))
+		if err != nil {
+			return fmt.Errorf("error writing to indexed path: %s", err)
 		}
 	}
 	return writer.Flush()

--- a/utils/update_indexed_paths.go
+++ b/utils/update_indexed_paths.go
@@ -18,7 +18,7 @@ func UpdateIndexedPaths(tree model.Tree) error {
 	if _, err := os.Stat(indexPath); err == nil {
 		file, err := os.Open(indexPath)
 		if err != nil {
-			return fmt.Errorf("error opening indexed path: %s", err)
+			return fmt.Errorf("error opening indexed path: %w", err)
 		}
 		defer func() {
 			closeErr := file.Close()
@@ -42,7 +42,7 @@ func UpdateIndexedPaths(tree model.Tree) error {
 
 	file, err := os.OpenFile(indexPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
 	if err != nil {
-		return fmt.Errorf("error opening indexed path: %s", err)
+		return fmt.Errorf("error opening indexed path: %w", err)
 	}
 	defer func() {
 		closeErr := file.Close()
@@ -55,7 +55,7 @@ func UpdateIndexedPaths(tree model.Tree) error {
 	for name, hash := range existing {
 		_, err := writer.WriteString(fmt.Sprintf("%s,%s\n", name, hash))
 		if err != nil {
-			return fmt.Errorf("error writing to indexed path: %s", err)
+			return fmt.Errorf("error writing to indexed path: %w", err)
 		}
 	}
 	return writer.Flush()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added push command with local/remote targets and set-remote configuration.
  - Diff now supports -v flag and detects new, modified, and deleted files with inline diffs.
  - Commit accepts multi-word messages; add now recursively handles directories (skips .got).
  - Restore prints success and returns errors instead of exiting.

- Documentation
  - Updated README wording, examples, and command references; improved help text formatting.
  - Revised setup scripts for Windows and Linux/macOS, aligning executable name and PATH guidance.

- Tests
  - Added comprehensive tests for diff, blob/commit/tree deserialization and retrieval, staging, and indexing.

- Chores
  - Added script to verify Go files have corresponding unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->